### PR TITLE
Fixed crash that occurs when opening .kdb file.

### DIFF
--- a/IOStream/InputStream.m
+++ b/IOStream/InputStream.m
@@ -25,11 +25,12 @@
 }
 
 - (NSData*)readData:(NSUInteger)length {
-    uint8_t bytes[length];
-    
+    uint8_t *bytes = calloc(sizeof(uint8_t), length);
     [self read:bytes length:length];
-    
-    return [NSData dataWithBytes:bytes length:length];
+
+    id data = [NSData dataWithBytes:bytes length:length];
+    free(bytes);
+    return data;
 }
 
 - (uint8_t)readInt8 {


### PR DESCRIPTION
- This only occurs on some devices. It was consistently reproducible on a retina ipad (ios 6) and on an iphone 4 (ios 5).
- It was caused by writing to unallocated memory.
