### PR TITLE
Fixes UUID problem #136 and allows edits on device to work with KeePassX on Mac

### DIFF
--- a/KeePassLib/Kdb4Parser.h
+++ b/KeePassLib/Kdb4Parser.h
@@ -28,4 +28,7 @@
 - (id)initWithRandomStream:(RandomStream*)cryptoRandomStream;
 - (Kdb4Tree*)parse:(InputStream*)inputStream;
 
+- (void)parseTimesElement:(DDXMLElement *)timesElement intoGroup:(Kdb4Group *)group;
+- (void)parseTimesElement:(DDXMLElement *)timesElement intoEntry:(Kdb4Entry *)entry;
+
 @end

--- a/KeePassLib/Kdb4Parser.m
+++ b/KeePassLib/Kdb4Parser.m
@@ -130,21 +130,15 @@ int closeCallback(void *context) {
     }
 }
 
-- (Kdb4Group *)parseGroup:(DDXMLElement *)root {
-    Kdb4Group *group = [[[Kdb4Group alloc] initWithElement:root] autorelease];
-    
-    DDXMLElement *element = [root elementForName:@"IconID"];
-    group.image = element.stringValue.intValue;
-    
-    element = [root elementForName:@"Name"];
-    group.name =  element.stringValue;
-    
-    DDXMLElement *timesElement = [root elementForName:@"Times"];
-    
+- (void)parseTimesElement:(DDXMLElement *)timesElement intoGroup:(Kdb4Group *)group
+{
     NSString *str = [[timesElement elementForName:@"CreationTime"] stringValue];
     group.creationTime = [dateFormatter dateFromString:str];
     
     str = [[timesElement elementForName:@"LastModificationTime"] stringValue];
+#ifdef DEBUG
+    NSDate *modifcationTime = [dateFormatter dateFromString:str];
+#endif
     group.lastModificationTime = [dateFormatter dateFromString:str];
     
     str = [[timesElement elementForName:@"LastAccessTime"] stringValue];
@@ -152,6 +146,26 @@ int closeCallback(void *context) {
     
     str = [[timesElement elementForName:@"ExpiryTime"] stringValue];
     group.expiryTime = [dateFormatter dateFromString:str];
+    
+}
+// reads from DOM into datastructure
+- (Kdb4Group *)parseGroup:(DDXMLElement *)root {
+    Kdb4Group *group = [[[Kdb4Group alloc] initWithElement:root] autorelease];
+    
+    DDXMLElement *element = [root elementForName:@"IconID"];
+    group.image = element.stringValue.intValue;
+
+    // HBXX
+    element = [root elementForName:@"UUID"];
+    NSString * lUUID = element.stringValue;
+    const char *lUUIDstr = [lUUID UTF8String];
+    
+    
+    element = [root elementForName:@"Name"];
+    group.name =  element.stringValue;
+    
+    DDXMLElement *timesElement = [root elementForName:@"Times"];
+    [self parseTimesElement:timesElement intoGroup:group];
     
     for (DDXMLElement *element in [root elementsForName:@"Entry"]) {
         Kdb4Entry *entry = [self parseEntry:element];
@@ -170,17 +184,15 @@ int closeCallback(void *context) {
     return group;
 }
 
-- (Kdb4Entry *)parseEntry:(DDXMLElement *)root {
-    Kdb4Entry *entry = [[[Kdb4Entry alloc] initWithElement:root] autorelease];
-    
-    entry.image = [[[root elementForName:@"IconID"] stringValue] intValue];
-    
-    DDXMLElement *timesElement = [root elementForName:@"Times"];
-    
+- (void)parseTimesElement:(DDXMLElement *)timesElement intoEntry:(Kdb4Entry *)entry
+{
     NSString *str = [[timesElement elementForName:@"CreationTime"] stringValue];
     entry.creationTime = [dateFormatter dateFromString:str];
     
     str = [[timesElement elementForName:@"LastModificationTime"] stringValue];
+#ifdef DEBUG
+    NSDate *modifcationTime = [dateFormatter dateFromString:str];
+#endif
     entry.lastModificationTime = [dateFormatter dateFromString:str];
     
     str = [[timesElement elementForName:@"LastAccessTime"] stringValue];
@@ -189,6 +201,16 @@ int closeCallback(void *context) {
     str = [[timesElement elementForName:@"ExpiryTime"] stringValue];
     entry.expiryTime = [dateFormatter dateFromString:str];
     
+}
+
+- (Kdb4Entry *)parseEntry:(DDXMLElement *)root {
+    Kdb4Entry *entry = [[[Kdb4Entry alloc] initWithElement:root] autorelease];
+    
+    entry.image = [[[root elementForName:@"IconID"] stringValue] intValue];
+    
+    DDXMLElement *timesElement = [root elementForName:@"Times"];
+    [self parseTimesElement:timesElement intoEntry:entry];
+        
     for (DDXMLElement *element in [root elementsForName:@"String"]) {
         NSString *key = [[element elementForName:@"Key"] stringValue];
 

--- a/KeePassLib/Kdb4Persist.m
+++ b/KeePassLib/Kdb4Persist.m
@@ -64,6 +64,10 @@
     [self decodeProtected:tree.document.rootElement];
 }
 
+// NOTE:
+// This supposes that the group's structures are up to date
+// if group.lastModificationTime is nil, this will be bad.
+// updates DOM from structures
 - (void)updateGroup:(Kdb4Group*)group {
     DDXMLElement *element;
     
@@ -80,6 +84,12 @@
     
     element = [timesElement elementForName:@"LastModificationTime"];
     element.stringValue = [dateFormatter stringFromDate:group.lastModificationTime];
+#ifdef DEBUG
+    NSDate* lDate = group.lastModificationTime;
+    NSLog(@"date: \"%@\"",[lDate description]);
+    NSString* lDateStr = [dateFormatter stringFromDate:group.lastModificationTime];
+    NSLog(@"datestr: \"%@\"",lDateStr);
+#endif
     
     element = [timesElement elementForName:@"LastAccessTime"];
     element.stringValue = [dateFormatter stringFromDate:group.lastAccessTime];
@@ -115,7 +125,7 @@
     
     timeElement = [timesElement elementForName:@"ExpiryTime"];
     timeElement.stringValue = [dateFormatter stringFromDate:entry.expiryTime];
-    
+
     for (DDXMLElement *element in [root elementsForName:@"String"]) {
         NSString *key = [[element elementForName:@"Key"] stringValue];
         

--- a/KeePassLib/UUID.h
+++ b/KeePassLib/UUID.h
@@ -26,6 +26,8 @@
 - (id)initWithBytes:(uint8_t*)bytes;
 - (void)getBytes:(uint8_t*)bytes length:(NSUInteger)length;
 
+- (NSString*)inBase64;
+
 + (UUID*)getAESUUID;
 
 @end

--- a/KeePassLib/UUID.m
+++ b/KeePassLib/UUID.m
@@ -16,6 +16,7 @@
  */
 
 #import "UUID.h"
+#import "Base64.h"
 
 static UUID *AES_UUID;
 
@@ -69,6 +70,18 @@ static UUID *AES_UUID;
 
 - (NSString*)description {
     NSString *uuidString = (NSString *)CFUUIDCreateString(NULL, uuid);
+    return [uuidString autorelease];
+}
+
+- (NSString*)inBase64 {
+    CFUUIDBytes uuidBytes1 = CFUUIDGetUUIDBytes(uuid);
+    
+    NSData *data = [ NSData dataWithBytes:&uuidBytes1 length:16];
+    // Base64 encode the string
+    NSData *dataBase64 = [Base64 encode:data];
+    
+    
+    NSString *uuidString = [[NSString alloc] initWithBytes:dataBase64.bytes length:dataBase64.length encoding:NSUTF8StringEncoding];
     return [uuidString autorelease];
 }
 

--- a/MiniKeePass.xcodeproj/project.pbxproj
+++ b/MiniKeePass.xcodeproj/project.pbxproj
@@ -1651,6 +1651,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MiniKeePass/MiniKeePass-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1724,6 +1725,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MiniKeePass/MiniKeePass-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1744,6 +1746,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MiniKeePass/MiniKeePass-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;


### PR DESCRIPTION
fixes #136

It fixes the larger problem of creating files on MiniKeePass, editing there
and seeing changes on Mac KeePassX (2.0 alpha 3).

NOTE: the UUID on KeePassX are encoded in base64 (it takes up 24 bytes, which decoded yield the 16 bytes hex id).  I could not find any documentation on the format, only by looking at the code of KeePassX

Fixed problems with times.  Sometimes they were left blank.
KeePassX does not like empty fields.

Fixing problems with group's times datastructures and UUID
- KeePassX expects UUID to be in Base64 and all times (modification,
  creation…) not to be empty.
- added UUID inBase64 method.
- updating group's UUID as well as LastTopVisibleEntry, as well as for entries
- Removed optimizations for debug version to properly debug.
