### PR TITLE
Fixed new entry crash

### DIFF
--- a/MiniKeePass/EntryViewController.m
+++ b/MiniKeePass/EntryViewController.m
@@ -117,11 +117,15 @@ enum {
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-
+    
     // Add listeners to the keyboard
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
+}
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
     if (self.isNewEntry) {
         [self setEditing:YES animated:NO];
         [titleCell.textField becomeFirstResponder];


### PR DESCRIPTION
Crash on iOS 7 simulator when trying to add new entry.
