### PR TITLE
Hide empty toolbar on add/edit entry screen

### DIFF
--- a/MiniKeePass/EntryViewController.m
+++ b/MiniKeePass/EntryViewController.m
@@ -117,7 +117,8 @@ enum {
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
+    self.navigationController.toolbarHidden = YES;
+
     // Add listeners to the keyboard
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];

--- a/MiniKeePass/GroupViewController.m
+++ b/MiniKeePass/GroupViewController.m
@@ -112,6 +112,8 @@ enum {
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    self.navigationController.toolbarHidden = NO;
+
     // Update the search bar's placeholder
     self.searchDisplayController.searchBar.placeholder = [NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Search", nil), self.title];
 


### PR DESCRIPTION
As far as I can tell, the toolbar will always be empty on the add/edit entry screen.

I think it looks a little cleaner to hide the toolbar rather than leave it empty. Any thoughts?