### PR TITLE
Fixed issue #406 where Touch ID could be bypassed without prompting f…

### DIFF
--- a/MiniKeePass/Lock Screen/LockScreenManager.m
+++ b/MiniKeePass/Lock Screen/LockScreenManager.m
@@ -317,7 +317,9 @@ static LockScreenManager *sharedInstance = nil;
     if ([self shouldCheckPin]) {
         [self checkPin];
     } else {
-        [self hideLockScreen];
+        if (!self.checkingTouchId) {
+            [self hideLockScreen];
+        }
     }
 }
 


### PR DESCRIPTION
…or the PIN code

If an unauthorized user fully pressed the home button while the Touch ID prompt was displayed, the lock screen would be hidden before the PIN code view controller was shown. The net effect is that the unauthorized user would be able to able to access the database without being prompted for the app's PIN code.