### PR TITLE
Fix TextFieldCell layout issues

### DIFF
--- a/MiniKeePass/Cells/TextFieldCell.m
+++ b/MiniKeePass/Cells/TextFieldCell.m
@@ -28,18 +28,7 @@
 - (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        int inset;
-        if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
-            inset = 83;
-        } else {
-            inset = 115;
-        }
-
-        CGRect frame = self.contentView.frame;
-        frame.origin.x = inset;
-        frame.size.width -= inset;
-        
-        _textField = [[UITextField alloc] initWithFrame:frame];
+        _textField = [[UITextField alloc] initWithFrame:CGRectZero];
         _textField.delegate = self;
         _textField.autocorrectionType = UITextAutocorrectionTypeNo;
         _textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -56,12 +45,26 @@
         CGFloat grayIntensity = 202.0 / 255.0;
         UIColor *color = [UIColor colorWithRed:grayIntensity green:grayIntensity blue:grayIntensity alpha:1];
 
-        _grayBar = [[UIView alloc] initWithFrame:CGRectMake(inset - 4, -1, 1, self.contentView.frame.size.height - 4)];
+        _grayBar = [[UIView alloc] initWithFrame:CGRectZero];
         _grayBar.backgroundColor = color;
         _grayBar.hidden = YES;
         [self.contentView addSubview:_grayBar];
     }
     return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    // Adjust the text field frame around the label
+    int inset = self.textLabel.frame.origin.x + self.textLabel.frame.size.width + 10;
+    CGRect textFieldFrame = self.contentView.frame;
+    textFieldFrame.origin.x = inset;
+    textFieldFrame.size.width -= inset;
+    _textField.frame = textFieldFrame;
+    
+    // Place the gray bar between the label and the text field
+    _grayBar.frame = CGRectMake(inset - 5, 0, 1, self.contentView.frame.size.height);
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {


### PR DESCRIPTION
Fix for issue #433.  There were some hard-coded offsets being used, which differed based on the OS version... so I guess something changed again.  An inset of about 150 seemed to be required for iPad Air 2 running iOS 9 in the simulator, but instead of  another hard-coded value, I moved the layout logic into `layoutSubviews` where the actual width of the label can be used.

Tested using iPad Air 2 and iPhone 5s running iOS 9.x in the simulator and seems to look OK on both.  I did wonder if the inset should be adjusted more on iPad vs iPhone, since in general the iPad uses much more white space, but I left them the same for now.

This is how it looks now on iPad:

![screen shot 2016-08-07 at 12 58 01 am](https://cloud.githubusercontent.com/assets/1621581/17460799/1fdc2d76-5c3a-11e6-9c67-0586e788834d.png)
