### PR TITLE
Updated Dropbox Import/Export text to be more specific and guided.

### DIFF
--- a/help/dropbox.html
+++ b/help/dropbox.html
@@ -1,31 +1,34 @@
 <html>
     <head>
         <link rel="stylesheet" type="text/css" href="style.css">
+        <meta charset="UTF-8">
     </head>
-    
+
     <body>
-        <h1>Adding files from Dropbox</h1>
-        
-        <p>KeePass files located on Dropbox can be added to MiniKeePass using the Dropbox app.</p>
-        
-        <h3>Steps:</h3>
-        <ul>
-            <li>Open the Dropbox app on your device</li>
-            <li>Navigate to your KeePass file</li>
-            <li>Tap the Action button in the toolbar</li>
-            <li>Select MiniKeePass from the list that appears</li>
-        </ul>
-        
-        <h1>Uploading files to Dropbox</h1>
-        
-        <p>MiniKeePass will not automatically sync files with Dropbox.  Follow these steps to export your KeePass files to the Dropbox app.</p>
-        
-        <h3>Steps:</h3>
-        <ul>
-            <li>Open MiniKeePass on your device</li>
-            <li>Open the file to be exported</li>
-            <li>Tap the Action button in the toolbar</li>
-            <li>Select Dropbox from the list that appears</li>
-        </ul>
+      <h1>Adding files to Dropbox</h1>
+
+      <p>KeePass files located in Dropbox can be added to MiniKeePass using the Dropbox app. <em>MiniKeePass will not automatically fetch the database file when it is updated on Dropbox</em></p>
+
+      <ol>
+        <li>Open Dropbox</li>
+        <li>Navigate to your KeePass database file and open it.</li>
+        <li>Tap the ... icon in the top right hand corner.</li>
+        <li>Tap &quot;Export&quot;</li>
+        <li>Select &quot;Open In...&quot;</li>
+        <li>Find &quot;Copy to MiniKeePass&quot; and tap it.</li>
+        <li>Your KeePass database will open in MiniKeePass and now be listed under &quot;Databases&quot;</li>
+      </ol>
+
+      <h1>Uploading files to Dropbox</h1>
+
+      <p><em>MiniKeePass will not automatically sync files with Dropbox. Follow these steps to export your KeePass files to the Dropbox app.</em></p>
+
+      <ol>
+        <li>Open MiniKeePass</li>
+        <li>Open the database you want to export.</li>
+        <li>Tap the action button on the bottom toolbar.</li>
+        <li>Select &quot;Import with Dropbox&quot;</li>
+        <li>Choose a location on the Dropbox app and tap save.</li>
+      </ol>
     </body>
 </html>


### PR DESCRIPTION
I had some trouble adding my KeePass file from Dropbox on MiniKeePass. Reading the instructions only helped a little, because they weren't specific or guided. Took me a little longer than it usually would've, so I decided to re-write the Dropbox Import/Export help page.