### PR TITLE
Fixes for issues 554 and 555

### DIFF
--- a/MiniKeePass/Entry View/EntryViewController.m
+++ b/MiniKeePass/Entry View/EntryViewController.m
@@ -53,6 +53,7 @@ enum {
 @end
 
 static NSString *TextFieldCellIdentifier = @"TextFieldCell";
+static NSString *CustomFieldCellIdentifier = @"CustomFieldCell";
 
 @implementation EntryViewController
 
@@ -61,7 +62,8 @@ static NSString *TextFieldCellIdentifier = @"TextFieldCell";
     self.navigationItem.rightBarButtonItem = self.editButtonItem;
     
     [self.tableView registerNib:[UINib nibWithNibName:@"TextFieldCell" bundle:nil] forCellReuseIdentifier:TextFieldCellIdentifier];
-    
+    [self.tableView registerNib:[UINib nibWithNibName:@"TextFieldCell" bundle:nil] forCellReuseIdentifier:CustomFieldCellIdentifier];
+
     titleCell = [self.tableView dequeueReusableCellWithIdentifier:TextFieldCellIdentifier];
     titleCell.style = TextFieldCellStyleTitle;
     titleCell.title = NSLocalizedString(@"Title", nil);
@@ -109,6 +111,8 @@ static NSString *TextFieldCellIdentifier = @"TextFieldCell";
     _defaultCells = @[titleCell, usernameCell, passwordCell, urlCell];
     
     _editingStringFields = [NSMutableArray array];
+    
+    self.tableView.allowsSelectionDuringEditing = YES;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -403,13 +407,13 @@ static NSString *TextFieldCellIdentifier = @"TextFieldCell";
 
                 return cell;
             } else {
-                TextFieldCell *cell = [tableView dequeueReusableCellWithIdentifier:TextFieldCellIdentifier];
+                TextFieldCell *cell = [tableView dequeueReusableCellWithIdentifier:CustomFieldCellIdentifier];
                 if (cell == nil) {
                     cell = [[TextFieldCell alloc] initWithStyle:UITableViewCellStyleValue2
-                                                reuseIdentifier:TextFieldCellIdentifier];
-                    cell.delegate = self;
-                    cell.textField.returnKeyType = UIReturnKeyDone;
+                                                reuseIdentifier:CustomFieldCellIdentifier];
                 }
+                cell.delegate = self;
+                cell.textField.returnKeyType = UIReturnKeyDone;
 
                 StringField *stringField = [self.currentStringFields objectAtIndex:indexPath.row];
 

--- a/MiniKeePass/Password Entry View/KeyFileViewController.swift
+++ b/MiniKeePass/Password Entry View/KeyFileViewController.swift
@@ -54,10 +54,10 @@ class KeyFileViewController: UITableViewController {
 
         if (indexPath != oldIndexPath) {
             let oldCell = tableView.cellForRow(at: oldIndexPath)
-            oldCell!.accessoryType = .none
+            oldCell?.accessoryType = .none
             
             let cell = tableView.cellForRow(at: indexPath)
-            cell!.accessoryType = .checkmark
+            cell?.accessoryType = .checkmark
             
             selectedKeyIndex = keyIndex
             


### PR DESCRIPTION
Fixes for issues #554 and #555.  The custom field bug was due to the Default field cells be reused.  I created another pool of identifiers for the custom fields but there is probably a better way to keep the default field cells out of the reusable pool of cells.  

Also it seems that switching to using an XIB file makes `dequeueReusableCellWithIndenitifier:` always return with a cell rather than returning with nil (maybe?).  The delegate was not getting set for the custom fields and so changes were not being saved.