### PR TITLE
Allow more file-extensions for keyfiles

### DIFF
--- a/MiniKeePass/MiniKeePass-Info.plist
+++ b/MiniKeePass/MiniKeePass-Info.plist
@@ -169,6 +169,7 @@
 					<string>jpg</string>
 					<string>png</string>
 					<string>svg</string>
+					<string>ics</string>
 					<string>txt</string>
 					<string>zip</string>
 				</array>

--- a/MiniKeePass/MiniKeePass-Info.plist
+++ b/MiniKeePass/MiniKeePass-Info.plist
@@ -164,6 +164,13 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>key</string>
+					<string>pdf</string>
+					<string>gif</string>
+					<string>jpg</string>
+					<string>png</string>
+					<string>svg</string>
+					<string>txt</string>
+					<string>zip</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
MiniKeePass currently only accepts keyfiles with the extension .key - if a keyfile is disguised as a different filetype, it is not possible to copy it to MiniKeePass.

With this change, the file-extension of a keyfile can be changed to .pdf, .gif, .jpg, .png, .svg, .txt or .zip and copied to MiniKeePass.