### PR TITLE
Change instruction title to be consistent with the parent menu title.

### DIFF
--- a/help/dropbox.html
+++ b/help/dropbox.html
@@ -5,12 +5,12 @@
     </head>
 
     <body>
-      <h1>Adding files to Dropbox</h1>
+      <h1>Importing from Dropbox</h1>
 
       <p>KeePass files located in Dropbox can be added to MiniKeePass using the Dropbox app. <em>MiniKeePass will not automatically fetch the database file when it is updated on Dropbox</em></p>
 
       <ol>
-        <li>Open Dropbox</li>
+        <li>Open Dropbox.</li>
         <li>Navigate to your KeePass database file and open it.</li>
         <li>Tap the ... icon in the top right hand corner.</li>
         <li>Tap &quot;Export&quot;</li>
@@ -19,12 +19,12 @@
         <li>Your KeePass database will open in MiniKeePass and now be listed under &quot;Databases&quot;</li>
       </ol>
 
-      <h1>Uploading files to Dropbox</h1>
+      <h1>Exporting to Dropbox</h1>
 
       <p><em>MiniKeePass will not automatically sync files with Dropbox. Follow these steps to export your KeePass files to the Dropbox app.</em></p>
 
       <ol>
-        <li>Open MiniKeePass</li>
+        <li>Open MiniKeePass.</li>
         <li>Open the database you want to export.</li>
         <li>Tap the action button on the bottom toolbar.</li>
         <li>Select &quot;Import with Dropbox&quot;</li>


### PR DESCRIPTION
This is to make consistent with parent menu title that says "Dropbox Import/Export". Also it was meant to be "Adding files **from** Dropbox". 