### PR TITLE
Fix lockscreen exit time bug #566

### DIFF
--- a/MiniKeePass/Lock Screen/LockScreenManager.m
+++ b/MiniKeePass/Lock Screen/LockScreenManager.m
@@ -271,7 +271,10 @@ static LockScreenManager *sharedInstance = nil;
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification {
     AppSettings *appSettings = [AppSettings sharedInstance];
-    [appSettings setExitTime:[NSDate date]];
+    // Only set the exit time if the application is currently unlocked
+    if (lockWindow.isHidden) {
+        [appSettings setExitTime:[NSDate date]];
+    }
     [self.pinViewController showPinKeypad:[appSettings pinEnabled]];
     [lockWindow makeKeyAndVisible];
 }


### PR DESCRIPTION
If the application was brought to the foreground and not unlocked
and sent to the background then the exit time would erroneously get
reset.  If a non-zero pin timeout is used then the app would unlock if
brought back to the foreground bypassing the PIN screen.

This only affected non-zero pin timeout settings as far as I can tell.