### PR TITLE
Set readonly files to read/write on import

### DIFF
--- a/MiniKeePass/AppDelegate.m
+++ b/MiniKeePass/AppDelegate.m
@@ -101,6 +101,11 @@
     }
     [fileManager moveItemAtURL:url toURL:[NSURL fileURLWithPath:path] error:nil];
 
+    // Make sure the file is writable.
+    if (![fileManager isWritableFileAtPath:path]) {
+        [fileManager setAttributes:@{NSFilePosixPermissions:@0711} ofItemAtPath:path error:nil];
+    }
+    
     // Set file protection on the new file
     [fileManager setAttributes:@{NSFileProtectionKey:NSFileProtectionComplete} ofItemAtPath:path error:nil];
 


### PR DESCRIPTION
Check files that are imported into MKP to make sure the file
permissions are set to read/write.  OneDrive was setting them
to readonly which caused MKP to crash when attempting to save.

Fix for issue #571 