### PR TITLE
Change git submodule URL to https:// link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MBProgressHUD"]
 	path = MBProgressHUD
-	url = git@github.com:MiniKeePass/MBProgressHUD.git
+	url = https://github.com/MiniKeePass/MBProgressHUD


### PR DESCRIPTION
Prevents git from complaining about a missing public key when cloning