### PR TITLE
[495] Add fine grained control remembering database passwords

### DIFF
--- a/MiniKeePass/DatabaseManager.h
+++ b/MiniKeePass/DatabaseManager.h
@@ -30,8 +30,10 @@
 - (NSURL *)getFileUrl:(NSString *)filename;
 - (NSDate *)getFileLastModificationDate:(NSURL *)url;
 - (void)deleteFile:(NSString *)filename;
-- (void)newDatabase:(NSURL *)url password:(NSString *)password version:(NSInteger)version;
+- (void)newDatabase:(NSURL *)url password:(NSString *)password version:(NSInteger)version rememberPassword:(bool)rememberPassword;
 - (void)renameDatabase:(NSURL *)originalUrl newUrl:(NSURL *)newUrl;
+- (bool)hasRememberedDatabasePassword:(NSString *)filename;
+- (void)forgetDatabasePassword:(NSString *)filename;
 
 /// Open the specified KeePass DatabaseDocument
 /// @param path Path to the chosen KeePass DatabaseDocument

--- a/MiniKeePass/Files View/FilesViewController.swift
+++ b/MiniKeePass/Files View/FilesViewController.swift
@@ -180,14 +180,25 @@ class FilesViewController: UITableViewController, NewDatabaseDelegate {
             self.renameRowAtIndexPath(indexPath)
         }
         
+        let forgetPasswordAction = UITableViewRowAction(style: .normal, title: NSLocalizedString("Forget Password", comment: "")) { (action: UITableViewRowAction, indexPath: IndexPath) -> Void in
+            self.forgetPasswordRowAtIndexPath(indexPath)
+        }
+        forgetPasswordAction.backgroundColor = UIColor.orange
+
         switch Section.AllValues[indexPath.section] {
         case .databases:
-            return [deleteAction, renameAction]
+            var actions = [deleteAction, renameAction]
+
+            let databaseManager = DatabaseManager.sharedInstance()
+            if (databaseManager?.hasRememberedDatabasePassword(databaseFiles[indexPath.row]) ?? false) {
+                actions += [forgetPasswordAction]
+            }
+            return actions
         case .keyFiles:
             return [deleteAction]
         }
     }
-    
+
     func renameRowAtIndexPath(_ indexPath: IndexPath) {
         let storyboard = UIStoryboard(name: "RenameDatabase", bundle: nil)
         let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
@@ -228,6 +239,13 @@ class FilesViewController: UITableViewController, NewDatabaseDelegate {
         tableView.deleteRows(at: [indexPath], with: .fade)
     }
     
+    func forgetPasswordRowAtIndexPath(_ indexPath: IndexPath) {
+        let filename = databaseFiles[indexPath.row]
+
+        let databaseManager = DatabaseManager.sharedInstance()
+        databaseManager?.forgetDatabasePassword(filename)
+    }
+
     func newDatabaseCreated(filename: String) {
         let index = self.databaseFiles.insertionIndexOf(filename) {
             $0.localizedCaseInsensitiveCompare($1) == ComparisonResult.orderedAscending

--- a/MiniKeePass/New Database View/NewDatabase.storyboard
+++ b/MiniKeePass/New Database View/NewDatabase.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -125,6 +124,31 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="" footerTitle="" id="UbJ-8p-Xei">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0SV-NC-L3c">
+                                        <rect key="frame" x="0.0" y="295.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0SV-NC-L3c" id="nRq-ic-3p2">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ltz-Gd-Kkb">
+                                                    <rect key="frame" x="16" y="11" width="162" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gzZ-om-5mj" userLabel="Remember Password Switch">
+                                                    <rect key="frame" x="310" y="6" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="F1U-jU-Mc4" id="jOU-48-qLq"/>
@@ -147,6 +171,8 @@
                         <outlet property="confirmPasswordTextField" destination="1zc-53-WNl" id="vmr-39-nph"/>
                         <outlet property="nameTextField" destination="9ru-GW-9oL" id="JaW-h1-Qhf"/>
                         <outlet property="passwordTextField" destination="663-pU-YMA" id="0Qk-Tx-pUS"/>
+                        <outlet property="rememberPasswordCell" destination="0SV-NC-L3c" id="At9-Zb-4pM"/>
+                        <outlet property="rememberPasswordSwitch" destination="gzZ-om-5mj" id="EX1-Bi-EG3"/>
                         <outlet property="versionSegmentedControl" destination="DbA-51-Ekb" id="K8h-nW-Puq"/>
                     </connections>
                 </tableViewController>

--- a/MiniKeePass/New Database View/NewDatabaseViewController.swift
+++ b/MiniKeePass/New Database View/NewDatabaseViewController.swift
@@ -24,11 +24,23 @@ class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var confirmPasswordTextField: UITextField!
     @IBOutlet weak var versionSegmentedControl: UISegmentedControl!
+    @IBOutlet weak var rememberPasswordSwitch: UISwitch!
+    @IBOutlet weak var rememberPasswordCell: UITableViewCell!
 
     var delegate: NewDatabaseDelegate?
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // Determine if the remember passwords switch is visible
+        let appSettings = AppSettings.sharedInstance() as AppSettings
+        let rememberPasswords = appSettings.rememberPasswords()
+        switch rememberPasswords {
+        case RememberPasswords.Always, RememberPasswords.Never:
+            rememberPasswordCell.isHidden = true;
+        case RememberPasswords.WhenConfigured:
+            rememberPasswordCell.isHidden = false;
+        }
         
         nameTextField.becomeFirstResponder()
     }
@@ -96,9 +108,11 @@ class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
         } catch {
         }
 
+        let rememberPassword = rememberPasswordSwitch.isOn
+
         // Create the new database
         let databaseManager = DatabaseManager.sharedInstance()
-        databaseManager?.newDatabase(url, password: password1, version: version)
+        databaseManager?.newDatabase(url, password: password1, version: version, rememberPassword: rememberPassword)
         
         delegate?.newDatabaseCreated(filename: url!.lastPathComponent)
         

--- a/MiniKeePass/Password Entry View/PasswordEntry.storyboard
+++ b/MiniKeePass/Password Entry View/PasswordEntry.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -92,6 +90,31 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="" footerTitle="" id="bS7-cL-PNq">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="qUT-Nd-GzR">
+                                        <rect key="frame" x="0.0" y="235.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qUT-Nd-GzR" id="zKp-ai-l19">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iwa-U5-gFg">
+                                                    <rect key="frame" x="16" y="11" width="162" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zeA-FR-3j1" userLabel="Remember Password Switch">
+                                                    <rect key="frame" x="310" y="6" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="baa-ia-a2E" id="tZC-dq-WMc"/>
@@ -113,6 +136,8 @@
                     <connections>
                         <outlet property="keyFileLabel" destination="4nL-La-6er" id="Kz3-vK-fma"/>
                         <outlet property="passwordTextField" destination="Mcq-z7-LJP" id="D0V-jF-ZMV"/>
+                        <outlet property="rememberPasswordCell" destination="qUT-Nd-GzR" id="76H-Ef-OuY"/>
+                        <outlet property="rememberPasswordSwitch" destination="zeA-FR-3j1" id="4Hh-cG-EQJ"/>
                         <outlet property="showImageView" destination="9qL-LU-s6o" id="fji-Zy-eoK"/>
                     </connections>
                 </tableViewController>

--- a/MiniKeePass/Password Entry View/PasswordEntryViewController.swift
+++ b/MiniKeePass/Password Entry View/PasswordEntryViewController.swift
@@ -21,6 +21,8 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var showImageView: UIImageView!
     @IBOutlet weak var keyFileLabel: UILabel!
+    @IBOutlet weak var rememberPasswordSwitch: UISwitch!
+    @IBOutlet weak var rememberPasswordCell: UITableViewCell!
 
     @objc var filename: String!
     
@@ -47,6 +49,10 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
         return passwordTextField.text
     }
 
+    @objc var rememberPassword: Bool {
+        return rememberPasswordSwitch.isOn
+    }
+
     @objc var donePressed: ((PasswordEntryViewController) -> Void)?
     @objc var cancelPressed: ((PasswordEntryViewController) -> Void)?
     
@@ -59,6 +65,16 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
             selectedKeyFileIndex = idx
         }
         
+        // Determine if the remember passwords switch is visible
+        let appSettings = AppSettings.sharedInstance() as AppSettings
+        let rememberPasswords = appSettings.rememberPasswords()
+        switch rememberPasswords {
+        case RememberPasswords.Always, RememberPasswords.Never:
+            rememberPasswordCell.isHidden = true;
+        case RememberPasswords.WhenConfigured:
+            rememberPasswordCell.isHidden = false;
+        }
+
         passwordTextField.becomeFirstResponder()
     }
     

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DTi-df-Pz8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DTi-df-Pz8">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -271,34 +270,32 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Remember Database Passwords" footerTitle="Stores remembered database passwords in the devices's secure keychain." id="JmW-Y4-S1N">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="yHa-W2-Lzd">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="r82-0A-7yI" detailTextLabel="ptL-1g-Uls" style="IBUITableViewCellStyleValue1" id="AWa-2T-wxu" userLabel="Remember Password Cell">
                                         <rect key="frame" x="0.0" y="713.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="yHa-W2-Lzd" id="Ui7-Ls-nTU">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="AWa-2T-wxu" id="Olh-ql-Qd9">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xMv-gl-Kfq">
-                                                    <rect key="frame" x="8" y="12" width="302" height="20"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r82-0A-7yI">
+                                                    <rect key="frame" x="16" y="12" width="79" height="19.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Ea4-fm-fzf">
-                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="rememberDatabasePasswordsEnabledChanged:" destination="mlm-01-Slc" eventType="valueChanged" id="lfr-FU-66w"/>
-                                                    </connections>
-                                                </switch>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ptL-1g-Uls">
+                                                    <rect key="frame" x="298.5" y="12" width="41.5" height="19.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Ea4-fm-fzf" firstAttribute="centerY" secondItem="Ui7-Ls-nTU" secondAttribute="centerY" id="DvR-cF-KVg"/>
-                                                <constraint firstItem="Ea4-fm-fzf" firstAttribute="leading" secondItem="xMv-gl-Kfq" secondAttribute="trailing" constant="8" id="N4p-1a-5Hx"/>
-                                                <constraint firstItem="xMv-gl-Kfq" firstAttribute="leading" secondItem="Ui7-Ls-nTU" secondAttribute="leadingMargin" id="XyR-yR-YrF"/>
-                                                <constraint firstItem="xMv-gl-Kfq" firstAttribute="centerY" secondItem="Ui7-Ls-nTU" secondAttribute="centerY" id="kV1-iI-U6N"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Ea4-fm-fzf" secondAttribute="trailing" id="sGu-zB-5KY"/>
-                                            </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="oV7-qB-Seq" kind="show" identifier="Remember Passwords" id="K5D-6w-K6b"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -613,7 +610,7 @@
                         <outlet property="passwordEncodingCell" destination="p70-RW-3e7" id="kfr-qv-qmZ"/>
                         <outlet property="pinEnabledSwitch" destination="i82-ao-eaE" id="EnM-DA-stl"/>
                         <outlet property="pinLockTimeoutCell" destination="2QL-yf-Q2s" id="7Dh-Fl-MMH"/>
-                        <outlet property="rememberDatabasePasswordsEnabledSwitch" destination="Ea4-fm-fzf" id="7cF-hL-41B"/>
+                        <outlet property="rememberDatabasePasswordsCell" destination="AWa-2T-wxu" id="byH-Zi-eXV"/>
                         <outlet property="searchTitleOnlySwitch" destination="PQv-PG-Wrn" id="5XL-4A-aem"/>
                         <outlet property="sortingEnabledSwitch" destination="3lc-8w-xI4" id="grb-Ay-BBQ"/>
                         <outlet property="touchIdEnabledCell" destination="v5C-no-1Zp" id="Oe8-6J-urU"/>
@@ -643,6 +640,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="LOY-kv-rGe"/>
+        <segue reference="K5D-6w-K6b"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/MiniKeePass/Settings/AppSettings.h
+++ b/MiniKeePass/Settings/AppSettings.h
@@ -17,6 +17,12 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSInteger, RememberPasswords) {
+    Never = 0,
+    WhenConfigured = 1,
+    Always = 2,
+};
+
 @interface AppSettings : NSObject
 
 + (AppSettings *)sharedInstance;
@@ -54,8 +60,9 @@
 - (NSInteger)closeTimeoutIndex;
 - (void)setCloseTimeoutIndex:(NSInteger)closeTimeoutIndex;
 
-- (BOOL)rememberPasswordsEnabled;
-- (void)setRememberPasswordsEnabled:(BOOL)rememberPasswordsEnabled;
+- (RememberPasswords)rememberPasswords;
+- (NSInteger)rememberPasswordsIndex;
+- (void)setRememberPasswordsIndex:(NSInteger)rememberPasswordsIndex;
 
 - (BOOL)hidePasswords;
 - (void)setHidePasswords:(BOOL)hidePasswords;

--- a/MiniKeePass/Settings/AppSettings.m
+++ b/MiniKeePass/Settings/AppSettings.m
@@ -32,6 +32,7 @@
 #define DELETE_ON_FAILURE_ATTEMPTS @"deleteOnFailureAttempts"
 #define CLOSE_ENABLED              @"closeEnabled"
 #define CLOSE_TIMEOUT              @"closeTimeout"
+#define REMEMBER_PASSWORDS         @"rememberPasswords"
 #define REMEMBER_PASSWORDS_ENABLED @"rememberPasswordsEnabled"
 #define HIDE_PASSWORDS             @"hidePasswords"
 #define SORT_ALPHABETICALLY        @"sortAlphabetically"
@@ -57,6 +58,12 @@ static NSInteger pinLockTimeoutValues[] = {
     60,
     120,
     300
+};
+
+static RememberPasswords rememberPasswordsValues[] = {
+    Never,
+    WhenConfigured,
+    Always
 };
 
 static NSInteger deleteOnFailureAttemptsValues[] = {
@@ -118,7 +125,7 @@ static AppSettings *sharedInstance;
         [defaultsDict setValue:[NSNumber numberWithInt:1] forKey:DELETE_ON_FAILURE_ATTEMPTS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:CLOSE_ENABLED];
         [defaultsDict setValue:[NSNumber numberWithInt:4] forKey:CLOSE_TIMEOUT];
-        [defaultsDict setValue:[NSNumber numberWithBool:NO] forKey:REMEMBER_PASSWORDS_ENABLED];
+        [defaultsDict setValue:[NSNumber numberWithInt:0] forKey:REMEMBER_PASSWORDS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:HIDE_PASSWORDS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:SORT_ALPHABETICALLY];
         [defaultsDict setValue:[NSNumber numberWithBool:NO] forKey:SEARCH_TITLE_ONLY];
@@ -187,6 +194,10 @@ static AppSettings *sharedInstance;
         if ([self versionCompare:version rhsVersion:@"1.5.2"] <= 0) {
             [self upgrade152];
         }
+    
+        if ([self versionCompare:version rhsVersion:@"1.7.2"] <= 0) {
+            [self upgrade172];
+        }
     }
 
     NSString *currentVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
@@ -219,6 +230,18 @@ static AppSettings *sharedInstance;
     [userDefaults removeObjectForKey:PIN_ENABLED];
     [userDefaults removeObjectForKey:PIN_LOCK_TIMEOUT];
     [userDefaults removeObjectForKey:PIN_FAILED_ATTEMPTS];
+}
+
+// Upgrade configuration from 1.7.2
+- (void)upgrade172 {
+    // Migrate the remember passwords enabled setting
+    BOOL rememberPasswordsEnabled = [userDefaults boolForKey:REMEMBER_PASSWORDS_ENABLED];
+    if (rememberPasswordsEnabled) {
+        [self setRememberPasswordsIndex:(2)];
+    }
+
+    // Remove the old keys
+    [userDefaults removeObjectForKey:REMEMBER_PASSWORDS_ENABLED];
 }
 
 - (NSString *)version {
@@ -357,12 +380,17 @@ static AppSettings *sharedInstance;
     [userDefaults setInteger:closeTimeoutIndex forKey:CLOSE_TIMEOUT];
 }
 
-- (BOOL)rememberPasswordsEnabled {
-    return [userDefaults boolForKey:REMEMBER_PASSWORDS_ENABLED];
+- (RememberPasswords)rememberPasswords {
+    NSInteger rememberPasswordsIndex = [self rememberPasswordsIndex];
+    return rememberPasswordsValues[rememberPasswordsIndex];
 }
 
-- (void)setRememberPasswordsEnabled:(BOOL)rememberPasswordsEnabled {
-    [userDefaults setBool:rememberPasswordsEnabled forKey:REMEMBER_PASSWORDS_ENABLED];
+- (NSInteger)rememberPasswordsIndex {
+    return [userDefaults integerForKey:REMEMBER_PASSWORDS];
+}
+
+- (void)setRememberPasswordsIndex:(NSInteger)rememberPasswordsIndex {
+    [userDefaults setInteger:rememberPasswordsIndex forKey:REMEMBER_PASSWORDS];
 }
 
 - (BOOL)hidePasswords {

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2011 Jason Rush and John Flanagan. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -114,6 +114,11 @@
 "Delete All Data on PIN Failure" = "Delete All Data on PIN Failure";
 "Close Database on Timeout" = "Close Database on Timeout";
 "Remember Database Passwords" = "Remember Database Passwords";
+"Remember" = "Remember";
+"Forget Password" = "Forget Password";
+"Never" = "Never";
+"When Configured" = "When Configured";
+"Always" = "Always";
 "Hide Passwords" = "Hide Passwords";
 "Password Encoding" = "Password Encoding";
 "Clear Clipboard on Timeout" = "Clear Clipboard on Timeout";


### PR DESCRIPTION
Fine grained control was added for remembering the database passwords.
This allows some database passwords to be remembered without
remembering all database passwords.

The on/off switch for remembering passwords was changed to a choice of
never, when configured, and always.

A new remember password switch is added to the new database and
password screens. This switch is only displayed when the "when
configured" option for remembering the password is selected.

All remembered database passwords are cleared if the never option is
selected.

A new option was added to the database swipe on the file screen for
forgetting individual remembered database passwords.

This was manually tested using the simulator with an iPhone XR with
iOS 12.1.