### PR TITLE
[652] Add option to cancel the set PIN screen without setting a PIN

### DIFF
--- a/MiniKeePass.xcodeproj/project.pbxproj
+++ b/MiniKeePass.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		435D9A7F2219241E001E4D4D /* SetPinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9A7E2219241E001E4D4D /* SetPinViewController.swift */; };
 		4E8C169316B3E871004195A1 /* fr-createdb.html in Resources */ = {isa = PBXBuildFile; fileRef = 4E8C168E16B3E871004195A1 /* fr-createdb.html */; };
 		4E8C169416B3E871004195A1 /* fr-dropbox.html in Resources */ = {isa = PBXBuildFile; fileRef = 4E8C168F16B3E871004195A1 /* fr-dropbox.html */; };
 		4E8C169516B3E871004195A1 /* fr-itunes.html in Resources */ = {isa = PBXBuildFile; fileRef = 4E8C169016B3E871004195A1 /* fr-itunes.html */; };
@@ -146,6 +147,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		435D9A7E2219241E001E4D4D /* SetPinViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPinViewController.swift; sourceTree = "<group>"; };
 		4E8C168E16B3E871004195A1 /* fr-createdb.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "fr-createdb.html"; sourceTree = "<group>"; };
 		4E8C168F16B3E871004195A1 /* fr-dropbox.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "fr-dropbox.html"; sourceTree = "<group>"; };
 		4E8C169016B3E871004195A1 /* fr-itunes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "fr-itunes.html"; sourceTree = "<group>"; };
@@ -795,6 +797,7 @@
 			isa = PBXGroup;
 			children = (
 				689EA6901D67F94600CF445E /* SelectionViewController.swift */,
+				435D9A7E2219241E001E4D4D /* SetPinViewController.swift */,
 				689EA6911D67F94600CF445E /* Settings.storyboard */,
 				689EA6921D67F94600CF445E /* SettingsViewController.swift */,
 			);
@@ -1019,6 +1022,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				689DFFE713A4273F005EBD36 /* main.m in Sources */,
+				435D9A7F2219241E001E4D4D /* SetPinViewController.swift in Sources */,
 				689D03CD13A42B63005EBD36 /* Base64.m in Sources */,
 				689FBE781AB27228005CB6BD /* KeychainUtils.m in Sources */,
 				689FBE681AB271C6005CB6BD /* PinViewController.m in Sources */,

--- a/MiniKeePass/AppDelegate.m
+++ b/MiniKeePass/AppDelegate.m
@@ -35,9 +35,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     _databaseDocument = nil;
     
-    // Store references to base view controllers
-    self.navigationController = (UINavigationController *) self.window.rootViewController;
-    self.filesViewController = (FilesViewController *) self.navigationController.topViewController;
+    [self initializeBaseViewControllers];
     
     // Add a pasteboard notification listener to support clearing the clipboard
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
@@ -129,6 +127,21 @@
     [filesViewController performSegueWithIdentifier:@"fileOpened" sender:self];
 }
 
+- (void)initializeBaseViewControllers {
+    // Store references to base view controllers
+    self.navigationController = (UINavigationController *) self.window.rootViewController;
+    self.filesViewController = (FilesViewController *) self.navigationController.topViewController;
+}
+
+- (void)reloadMainUI {
+    // Replace any open UIs with a newly created main app screen.
+    // This handles ensuring UI screens such as the integrated web browser do not remain open.
+    UIStoryboard *storyBoard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    UIViewController *controller = [storyBoard instantiateInitialViewController];
+    self.window.rootViewController = controller;
+    [self initializeBaseViewControllers];
+}
+
 - (void)closeDatabase {
     // Close any open database views
     [self.navigationController popToRootViewControllerAnimated:NO];
@@ -168,9 +181,11 @@
         [fileManager removeItemAtPath:[documentsDirectory stringByAppendingPathComponent:file] error:nil];
     }
 
-    // Clear the database names ane keyfile names
-    [self.filesViewController updateFiles];
-    [self.filesViewController.tableView reloadData];
+    // Delete cookies in the integrated browser
+    [WebBrowserViewController clearState];
+    
+    // Close all open UIs are load the main UI
+    [self reloadMainUI];
 }
 
 - (void)checkFileProtection {

--- a/MiniKeePass/AppDelegate.m
+++ b/MiniKeePass/AppDelegate.m
@@ -141,7 +141,7 @@
     AppSettings *appSettings = [AppSettings sharedInstance];
     [appSettings setPinFailedAttempts:0];
     [appSettings setPinEnabled:NO];
-    [appSettings setTouchIdEnabled:NO];
+    [appSettings setBiometricIdEnabled:NO];
 
     // Delete the PIN from the keychain
     [KeychainUtils deleteStringForKey:@"PIN" andServiceName:KEYCHAIN_PIN_SERVICE];

--- a/MiniKeePass/AppDelegate.m
+++ b/MiniKeePass/AppDelegate.m
@@ -167,6 +167,10 @@
     for (NSString *file in files) {
         [fileManager removeItemAtPath:[documentsDirectory stringByAppendingPathComponent:file] error:nil];
     }
+
+    // Clear the database names ane keyfile names
+    [self.filesViewController updateFiles];
+    [self.filesViewController.tableView reloadData];
 }
 
 - (void)checkFileProtection {

--- a/MiniKeePass/DatabaseManager.h
+++ b/MiniKeePass/DatabaseManager.h
@@ -30,8 +30,10 @@
 - (NSURL *)getFileUrl:(NSString *)filename;
 - (NSDate *)getFileLastModificationDate:(NSURL *)url;
 - (void)deleteFile:(NSString *)filename;
-- (void)newDatabase:(NSURL *)url password:(NSString *)password version:(NSInteger)version;
+- (void)newDatabase:(NSURL *)url password:(NSString *)password version:(NSInteger)version rememberPassword:(bool)rememberPassword;
 - (void)renameDatabase:(NSURL *)originalUrl newUrl:(NSURL *)newUrl;
+- (bool)hasRememberedDatabasePassword:(NSString *)filename;
+- (void)forgetDatabasePassword:(NSString *)filename;
 
 /// Open the specified KeePass DatabaseDocument
 /// @param path Path to the chosen KeePass DatabaseDocument

--- a/MiniKeePass/Files View/FilesViewController.swift
+++ b/MiniKeePass/Files View/FilesViewController.swift
@@ -180,14 +180,25 @@ class FilesViewController: UITableViewController, NewDatabaseDelegate {
             self.renameRowAtIndexPath(indexPath)
         }
         
+        let forgetPasswordAction = UITableViewRowAction(style: .normal, title: NSLocalizedString("Forget Password", comment: "")) { (action: UITableViewRowAction, indexPath: IndexPath) -> Void in
+            self.forgetPasswordRowAtIndexPath(indexPath)
+        }
+        forgetPasswordAction.backgroundColor = UIColor.orange
+
         switch Section.AllValues[indexPath.section] {
         case .databases:
-            return [deleteAction, renameAction]
+            var actions = [deleteAction, renameAction]
+
+            let databaseManager = DatabaseManager.sharedInstance()
+            if (databaseManager?.hasRememberedDatabasePassword(databaseFiles[indexPath.row]) ?? false) {
+                actions += [forgetPasswordAction]
+            }
+            return actions
         case .keyFiles:
             return [deleteAction]
         }
     }
-    
+
     func renameRowAtIndexPath(_ indexPath: IndexPath) {
         let storyboard = UIStoryboard(name: "RenameDatabase", bundle: nil)
         let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
@@ -228,6 +239,13 @@ class FilesViewController: UITableViewController, NewDatabaseDelegate {
         tableView.deleteRows(at: [indexPath], with: .fade)
     }
     
+    func forgetPasswordRowAtIndexPath(_ indexPath: IndexPath) {
+        let filename = databaseFiles[indexPath.row]
+
+        let databaseManager = DatabaseManager.sharedInstance()
+        databaseManager?.forgetDatabasePassword(filename)
+    }
+
     func newDatabaseCreated(filename: String) {
         let index = self.databaseFiles.insertionIndexOf(filename) {
             $0.localizedCaseInsensitiveCompare($1) == ComparisonResult.orderedAscending

--- a/MiniKeePass/Lock Screen/LockScreenManager.m
+++ b/MiniKeePass/Lock Screen/LockScreenManager.m
@@ -32,7 +32,7 @@
 
 @implementation LockScreenManager {
     UIWindow *lockWindow;
-    BOOL touchIDFailed;
+    BOOL biometricIDFailed;
 }
 
 static LockScreenManager *sharedInstance = nil;
@@ -48,7 +48,7 @@ static LockScreenManager *sharedInstance = nil;
 - (instancetype)init {
     self = [super init];
     if (self) {
-        touchIDFailed = NO;
+        biometricIDFailed = NO;
         
         lockWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
         lockWindow.windowLevel = UIWindowLevelAlert;
@@ -95,8 +95,8 @@ static LockScreenManager *sharedInstance = nil;
         return NO;
     }
     
-    // Check if touchID check failed
-    if (touchIDFailed) {
+    // Check if biometric ID check failed
+    if (biometricIDFailed) {
         return YES;
     }
 
@@ -112,10 +112,10 @@ static LockScreenManager *sharedInstance = nil;
 }
 
 - (void)checkPin {
-    // Perform Touch ID if enabled and not already failed.
+    // Perform biometric ID if enabled and not already failed.
     AppSettings *appSettings = [AppSettings sharedInstance];
-    if ([appSettings touchIdEnabled] && !touchIDFailed) {
-        [self showTouchId];
+    if ([appSettings biometricIdEnabled] && !biometricIDFailed) {
+        [self showBiometricId];
     }
 }
 
@@ -127,14 +127,14 @@ static LockScreenManager *sharedInstance = nil;
                      }
                      completion:^(BOOL finished){
                          [self.pinViewController clearPin];
-                         touchIDFailed = NO;
+                         biometricIDFailed = NO;
                          lockWindow.hidden = YES;
                          lockWindow.alpha = 1.0;
                      }];
 }
 
-- (void)showTouchId {
-    // Check if TouchID is supported
+- (void)showBiometricId {
+    // Check if Biometric ID is supported
     if (![NSClassFromString(@"LAContext") class]) {
         // Fallback to the PIN screen
         return;
@@ -143,14 +143,14 @@ static LockScreenManager *sharedInstance = nil;
     LAContext *context = [[LAContext alloc] init];
     context.localizedFallbackTitle = @""; // Hide the fallback button
 
-    // Check if Touch ID is available
+    // Check if Biometric ID is available
     NSError *error = nil;
     if (![context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
         // Fallback to the PIN screen
         return;
     }
     
-    touchIDFailed = NO;
+    biometricIDFailed = NO;
     
     // Authenticate User
     [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
@@ -163,7 +163,7 @@ static LockScreenManager *sharedInstance = nil;
                               });
                           } else {
                               // Failed, show the PIN screen
-                              touchIDFailed = YES;
+                              biometricIDFailed = YES;
                           }
                       }];
 }

--- a/MiniKeePass/Lock Screen/PinViewController.m
+++ b/MiniKeePass/Lock Screen/PinViewController.m
@@ -123,7 +123,7 @@
 }
 
 - (void)keypadViewAlphaPressed:(KeypadView *)keypadView {
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Enter your PIN to unlock", nil)
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:self.titleLabel.text
                                                         message:nil
                                                        delegate:self
                                               cancelButtonTitle:NSLocalizedString(@"Cancel", nil)

--- a/MiniKeePass/MiniKeePass-Info.plist
+++ b/MiniKeePass/MiniKeePass-Info.plist
@@ -83,6 +83,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>This app requires Face ID permission to authenticate using Face recognition rather than the PIN.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Andale Mono.ttf</string>

--- a/MiniKeePass/New Database View/NewDatabase.storyboard
+++ b/MiniKeePass/New Database View/NewDatabase.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sHd-VR-6rV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -125,6 +124,31 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="" footerTitle="" id="UbJ-8p-Xei">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0SV-NC-L3c">
+                                        <rect key="frame" x="0.0" y="295.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0SV-NC-L3c" id="nRq-ic-3p2">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ltz-Gd-Kkb">
+                                                    <rect key="frame" x="16" y="11" width="162" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="gzZ-om-5mj" userLabel="Remember Password Switch">
+                                                    <rect key="frame" x="310" y="6" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="F1U-jU-Mc4" id="jOU-48-qLq"/>
@@ -147,6 +171,8 @@
                         <outlet property="confirmPasswordTextField" destination="1zc-53-WNl" id="vmr-39-nph"/>
                         <outlet property="nameTextField" destination="9ru-GW-9oL" id="JaW-h1-Qhf"/>
                         <outlet property="passwordTextField" destination="663-pU-YMA" id="0Qk-Tx-pUS"/>
+                        <outlet property="rememberPasswordCell" destination="0SV-NC-L3c" id="At9-Zb-4pM"/>
+                        <outlet property="rememberPasswordSwitch" destination="gzZ-om-5mj" id="EX1-Bi-EG3"/>
                         <outlet property="versionSegmentedControl" destination="DbA-51-Ekb" id="K8h-nW-Puq"/>
                     </connections>
                 </tableViewController>

--- a/MiniKeePass/New Database View/NewDatabaseViewController.swift
+++ b/MiniKeePass/New Database View/NewDatabaseViewController.swift
@@ -24,11 +24,23 @@ class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var confirmPasswordTextField: UITextField!
     @IBOutlet weak var versionSegmentedControl: UISegmentedControl!
+    @IBOutlet weak var rememberPasswordSwitch: UISwitch!
+    @IBOutlet weak var rememberPasswordCell: UITableViewCell!
 
     var delegate: NewDatabaseDelegate?
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // Determine if the remember passwords switch is visible
+        let appSettings = AppSettings.sharedInstance() as AppSettings
+        let rememberPasswords = appSettings.rememberPasswords()
+        switch rememberPasswords {
+        case RememberPasswords.Always, RememberPasswords.Never:
+            rememberPasswordCell.isHidden = true;
+        case RememberPasswords.WhenConfigured:
+            rememberPasswordCell.isHidden = false;
+        }
         
         nameTextField.becomeFirstResponder()
     }
@@ -96,9 +108,11 @@ class NewDatabaseViewController: UITableViewController, UITextFieldDelegate {
         } catch {
         }
 
+        let rememberPassword = rememberPasswordSwitch.isOn
+
         // Create the new database
         let databaseManager = DatabaseManager.sharedInstance()
-        databaseManager?.newDatabase(url, password: password1, version: version)
+        databaseManager?.newDatabase(url, password: password1, version: version, rememberPassword: rememberPassword)
         
         delegate?.newDatabaseCreated(filename: url!.lastPathComponent)
         

--- a/MiniKeePass/Password Entry View/PasswordEntry.storyboard
+++ b/MiniKeePass/Password Entry View/PasswordEntry.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rxu-he-bvs">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -92,6 +90,31 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="" footerTitle="" id="bS7-cL-PNq">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="qUT-Nd-GzR">
+                                        <rect key="frame" x="0.0" y="235.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qUT-Nd-GzR" id="zKp-ai-l19">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iwa-U5-gFg">
+                                                    <rect key="frame" x="16" y="11" width="162" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zeA-FR-3j1" userLabel="Remember Password Switch">
+                                                    <rect key="frame" x="310" y="6" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="baa-ia-a2E" id="tZC-dq-WMc"/>
@@ -113,6 +136,8 @@
                     <connections>
                         <outlet property="keyFileLabel" destination="4nL-La-6er" id="Kz3-vK-fma"/>
                         <outlet property="passwordTextField" destination="Mcq-z7-LJP" id="D0V-jF-ZMV"/>
+                        <outlet property="rememberPasswordCell" destination="qUT-Nd-GzR" id="76H-Ef-OuY"/>
+                        <outlet property="rememberPasswordSwitch" destination="zeA-FR-3j1" id="4Hh-cG-EQJ"/>
                         <outlet property="showImageView" destination="9qL-LU-s6o" id="fji-Zy-eoK"/>
                     </connections>
                 </tableViewController>

--- a/MiniKeePass/Password Entry View/PasswordEntryViewController.swift
+++ b/MiniKeePass/Password Entry View/PasswordEntryViewController.swift
@@ -21,6 +21,8 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var showImageView: UIImageView!
     @IBOutlet weak var keyFileLabel: UILabel!
+    @IBOutlet weak var rememberPasswordSwitch: UISwitch!
+    @IBOutlet weak var rememberPasswordCell: UITableViewCell!
 
     @objc var filename: String!
     
@@ -47,6 +49,10 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
         return passwordTextField.text
     }
 
+    @objc var rememberPassword: Bool {
+        return rememberPasswordSwitch.isOn
+    }
+
     @objc var donePressed: ((PasswordEntryViewController) -> Void)?
     @objc var cancelPressed: ((PasswordEntryViewController) -> Void)?
     
@@ -59,6 +65,16 @@ class PasswordEntryViewController: UITableViewController, UITextFieldDelegate {
             selectedKeyFileIndex = idx
         }
         
+        // Determine if the remember passwords switch is visible
+        let appSettings = AppSettings.sharedInstance() as AppSettings
+        let rememberPasswords = appSettings.rememberPasswords()
+        switch rememberPasswords {
+        case RememberPasswords.Always, RememberPasswords.Never:
+            rememberPasswordCell.isHidden = true;
+        case RememberPasswords.WhenConfigured:
+            rememberPasswordCell.isHidden = false;
+        }
+
         passwordTextField.becomeFirstResponder()
     }
     

--- a/MiniKeePass/Settings View/SetPinViewController.swift
+++ b/MiniKeePass/Settings View/SetPinViewController.swift
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 Jason Rush and John Flanagan. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import UIKit
+import AudioToolbox
+
+class SetPinViewController: UIViewController, PinViewControllerDelegate {
+    
+    // The PIN keypad will be programatically added to the mainView
+    @IBOutlet weak var mainView: UIView!
+
+    fileprivate var appSettings = AppSettings.sharedInstance()
+    
+    fileprivate var tempPin: String? = nil
+    fileprivate var pinViewController: PinViewController = PinViewController()
+
+    
+    override func loadView() {
+        super.loadView()
+
+        self.pinViewController.titleLabel.text = NSLocalizedString("Set PIN", comment: "")
+        self.pinViewController.delegate = self
+        
+        self.mainView.addSubview(self.pinViewController.view)
+        self.pinViewController.didMove(toParentViewController:self)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // Delete the temp pin
+        tempPin = nil
+    }
+    
+    // MARK: - Pin view delegate
+    func pinViewController(_ pinViewController: PinViewController!, pinEntered: String!) {
+        if (tempPin == nil) {
+            tempPin = pinEntered
+            
+            pinViewController.titleLabel.text = NSLocalizedString("Confirm PIN", comment: "")
+            
+            // Clear the PIN entry for confirmation
+            pinViewController.clearPin()
+        } else if (tempPin == pinEntered) {
+            tempPin = nil
+            
+            // Hash the pin
+            let pinHash = PasswordUtils.hashPassword(pinEntered)
+            
+            // Set the PIN and enable the PIN enabled setting
+            appSettings?.setPin(pinHash)
+            appSettings?.setPinEnabled(true)
+            
+            // Remove the PIN view
+            // dismiss(animated: true, completion: nil)
+            navigationController?.popViewController(animated: true)
+        } else {
+            tempPin = nil
+            
+            // Notify the user the PINs they entered did not match
+            pinViewController.titleLabel.text = NSLocalizedString("PINs did not match. Try again", comment: "")
+            
+            // Vibrate the phone
+            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+            
+            // Clear the PIN entry to let them try again
+            pinViewController.clearPin()
+        }
+    }
+    
+}

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DTi-df-Pz8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="DTi-df-Pz8">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -271,34 +270,32 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Remember Database Passwords" footerTitle="Stores remembered database passwords in the devices's secure keychain." id="JmW-Y4-S1N">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="yHa-W2-Lzd">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="r82-0A-7yI" detailTextLabel="ptL-1g-Uls" style="IBUITableViewCellStyleValue1" id="AWa-2T-wxu" userLabel="Remember Password Cell">
                                         <rect key="frame" x="0.0" y="713.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="yHa-W2-Lzd" id="Ui7-Ls-nTU">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="AWa-2T-wxu" id="Olh-ql-Qd9">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xMv-gl-Kfq">
-                                                    <rect key="frame" x="8" y="12" width="302" height="20"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r82-0A-7yI">
+                                                    <rect key="frame" x="16" y="12" width="79" height="19.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Ea4-fm-fzf">
-                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="rememberDatabasePasswordsEnabledChanged:" destination="mlm-01-Slc" eventType="valueChanged" id="lfr-FU-66w"/>
-                                                    </connections>
-                                                </switch>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ptL-1g-Uls">
+                                                    <rect key="frame" x="298.5" y="12" width="41.5" height="19.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Ea4-fm-fzf" firstAttribute="centerY" secondItem="Ui7-Ls-nTU" secondAttribute="centerY" id="DvR-cF-KVg"/>
-                                                <constraint firstItem="Ea4-fm-fzf" firstAttribute="leading" secondItem="xMv-gl-Kfq" secondAttribute="trailing" constant="8" id="N4p-1a-5Hx"/>
-                                                <constraint firstItem="xMv-gl-Kfq" firstAttribute="leading" secondItem="Ui7-Ls-nTU" secondAttribute="leadingMargin" id="XyR-yR-YrF"/>
-                                                <constraint firstItem="xMv-gl-Kfq" firstAttribute="centerY" secondItem="Ui7-Ls-nTU" secondAttribute="centerY" id="kV1-iI-U6N"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Ea4-fm-fzf" secondAttribute="trailing" id="sGu-zB-5KY"/>
-                                            </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="oV7-qB-Seq" kind="show" identifier="Remember Passwords" id="K5D-6w-K6b"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -613,7 +610,7 @@
                         <outlet property="passwordEncodingCell" destination="p70-RW-3e7" id="kfr-qv-qmZ"/>
                         <outlet property="pinEnabledSwitch" destination="i82-ao-eaE" id="EnM-DA-stl"/>
                         <outlet property="pinLockTimeoutCell" destination="2QL-yf-Q2s" id="7Dh-Fl-MMH"/>
-                        <outlet property="rememberDatabasePasswordsEnabledSwitch" destination="Ea4-fm-fzf" id="7cF-hL-41B"/>
+                        <outlet property="rememberDatabasePasswordsCell" destination="AWa-2T-wxu" id="byH-Zi-eXV"/>
                         <outlet property="searchTitleOnlySwitch" destination="PQv-PG-Wrn" id="5XL-4A-aem"/>
                         <outlet property="sortingEnabledSwitch" destination="3lc-8w-xI4" id="grb-Ay-BBQ"/>
                         <outlet property="touchIdEnabledCell" destination="v5C-no-1Zp" id="Oe8-6J-urU"/>
@@ -643,6 +640,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="LOY-kv-rGe"/>
+        <segue reference="K5D-6w-K6b"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -142,10 +142,6 @@
                                             <segue destination="oV7-qB-Seq" kind="show" identifier="PIN Lock Timeout" id="PxN-Oo-5xq"/>
                                         </connections>
                                     </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="Delete All Data on PIN Failure" footerTitle="Delete all files and passwords after too many failed attempts." id="bnl-fj-Wky">
-                                <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="68h-n2-JDk">
                                         <rect key="frame" x="0.0" y="354.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -153,7 +149,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8ZA-aO-G1w">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Erase Data On Failure" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8ZA-aO-G1w">
                                                     <rect key="frame" x="16" y="12" width="286" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -182,8 +178,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Attempts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iK4-cj-HRD">
-                                                    <rect key="frame" x="16" y="12" width="66.5" height="19.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Attempts Before Erasing Data" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iK4-cj-HRD">
+                                                    <rect key="frame" x="16" y="12" width="214" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -602,6 +598,7 @@
                         <outlet property="closeDatabaseTimeoutCell" destination="0y2-e2-8ow" id="bdB-IZ-RGX"/>
                         <outlet property="deleteAllDataAttemptsCell" destination="0Rc-eI-Pdn" id="lw9-Xt-MpI"/>
                         <outlet property="deleteAllDataEnabledCell" destination="68h-n2-JDk" id="WTn-i6-KWM"/>
+                        <outlet property="deleteAllDataEnabledLabel" destination="8ZA-aO-G1w" id="OMm-nG-nyB"/>
                         <outlet property="deleteAllDataEnabledSwitch" destination="Vkp-4b-3XR" id="sDh-tf-ACx"/>
                         <outlet property="excludeFromBackupsEnabledSwitch" destination="7Ku-Wa-CXa" id="Rx2-qK-Omz"/>
                         <outlet property="hidePasswordsEnabledSwitch" destination="ofT-Wg-xcq" id="fV3-ZJ-xPx"/>

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -269,7 +269,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Remember Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r82-0A-7yI">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Remember Passwords" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r82-0A-7yI">
                                                     <rect key="frame" x="16" y="12" width="79" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -86,6 +86,35 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="v5C-no-1Zp">
+                                        <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="v5C-no-1Zp" id="pDY-h0-YIr">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Biometric ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="drK-Tr-LS6">
+                                                    <rect key="frame" x="16" y="12" width="286" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Ye5-jl-2bY">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="biometricIdEnabledChanged:" destination="mlm-01-Slc" eventType="valueChanged" id="8yt-L0-sIs"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Ye5-jl-2bY" firstAttribute="leading" secondItem="drK-Tr-LS6" secondAttribute="trailing" constant="8" id="9q6-6X-7md"/>
+                                                <constraint firstItem="Ye5-jl-2bY" firstAttribute="centerY" secondItem="pDY-h0-YIr" secondAttribute="centerY" id="Iez-wA-A3l"/>
+                                                <constraint firstItem="drK-Tr-LS6" firstAttribute="leading" secondItem="pDY-h0-YIr" secondAttribute="leadingMargin" id="STg-LJ-sSB"/>
+                                                <constraint firstItem="drK-Tr-LS6" firstAttribute="centerY" secondItem="pDY-h0-YIr" secondAttribute="centerY" id="b1s-mM-atn"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Ye5-jl-2bY" secondAttribute="trailing" id="d6V-LD-AtI"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="wtO-pi-5e5" detailTextLabel="f9f-6e-NYT" style="IBUITableViewCellStyleValue1" id="2QL-yf-Q2s">
                                         <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -112,39 +141,6 @@
                                         <connections>
                                             <segue destination="oV7-qB-Seq" kind="show" identifier="PIN Lock Timeout" id="PxN-Oo-5xq"/>
                                         </connections>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="Touch ID" footerTitle="Use your fingerprint as an alternative to entering a PIN if supported." id="vH4-cT-PCz">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="v5C-no-1Zp">
-                                        <rect key="frame" x="0.0" y="219" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="v5C-no-1Zp" id="pDY-h0-YIr">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="drK-Tr-LS6">
-                                                    <rect key="frame" x="16" y="12" width="286" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Ye5-jl-2bY">
-                                                    <rect key="frame" x="310" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="touchIdEnabledChanged:" destination="mlm-01-Slc" eventType="valueChanged" id="8yt-L0-sIs"/>
-                                                    </connections>
-                                                </switch>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Ye5-jl-2bY" firstAttribute="leading" secondItem="drK-Tr-LS6" secondAttribute="trailing" constant="8" id="9q6-6X-7md"/>
-                                                <constraint firstItem="Ye5-jl-2bY" firstAttribute="centerY" secondItem="pDY-h0-YIr" secondAttribute="centerY" id="Iez-wA-A3l"/>
-                                                <constraint firstItem="drK-Tr-LS6" firstAttribute="leading" secondItem="pDY-h0-YIr" secondAttribute="leadingMargin" id="STg-LJ-sSB"/>
-                                                <constraint firstItem="drK-Tr-LS6" firstAttribute="centerY" secondItem="pDY-h0-YIr" secondAttribute="centerY" id="b1s-mM-atn"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Ye5-jl-2bY" secondAttribute="trailing" id="d6V-LD-AtI"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -597,6 +593,9 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="biometricIdEnabledCell" destination="v5C-no-1Zp" id="Oe8-6J-urU"/>
+                        <outlet property="biometricIdEnabledSwitch" destination="Ye5-jl-2bY" id="cBy-Mo-Gym"/>
+                        <outlet property="biometricIdLabel" destination="drK-Tr-LS6" id="UBS-aZ-csy"/>
                         <outlet property="clearClipboardEnabledSwitch" destination="Amv-ka-cmc" id="7LU-aG-nxz"/>
                         <outlet property="clearClipboardTimeoutCell" destination="2F7-jl-P33" id="2Ue-Ht-Q2L"/>
                         <outlet property="closeDatabaseEnabledSwitch" destination="H69-KF-yqe" id="fS2-aO-7cl"/>
@@ -613,8 +612,6 @@
                         <outlet property="rememberDatabasePasswordsCell" destination="AWa-2T-wxu" id="byH-Zi-eXV"/>
                         <outlet property="searchTitleOnlySwitch" destination="PQv-PG-Wrn" id="5XL-4A-aem"/>
                         <outlet property="sortingEnabledSwitch" destination="3lc-8w-xI4" id="grb-Ay-BBQ"/>
-                        <outlet property="touchIdEnabledCell" destination="v5C-no-1Zp" id="Oe8-6J-urU"/>
-                        <outlet property="touchIdEnabledSwitch" destination="Ye5-jl-2bY" id="cBy-Mo-Gym"/>
                         <outlet property="versionLabel" destination="fc3-tI-Hn4" id="2Zn-w5-26K"/>
                     </connections>
                 </tableViewController>

--- a/MiniKeePass/Settings View/Settings.storyboard
+++ b/MiniKeePass/Settings View/Settings.storyboard
@@ -9,6 +9,28 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Set PIn View Controller-->
+        <scene sceneID="eCN-Wx-uUh">
+            <objects>
+                <viewController id="6EF-Is-b7B" userLabel="Set PIn View Controller" customClass="SetPinViewController" customModule="MiniKeePass" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="5od-99-kZe"/>
+                        <viewControllerLayoutGuide type="bottom" id="qyf-Xq-Aim"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Pbd-RM-B3E">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Set PIN" id="5z7-eY-nng" userLabel="Set Pin"/>
+                    <connections>
+                        <outlet property="mainView" destination="Pbd-RM-B3E" id="tqJ-3Z-Mlb"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xy3-bA-926" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="265" y="929"/>
+        </scene>
         <!--Selection View Controller-->
         <scene sceneID="PCT-np-FdE">
             <objects>
@@ -610,6 +632,7 @@
                         <outlet property="searchTitleOnlySwitch" destination="PQv-PG-Wrn" id="5XL-4A-aem"/>
                         <outlet property="sortingEnabledSwitch" destination="3lc-8w-xI4" id="grb-Ay-BBQ"/>
                         <outlet property="versionLabel" destination="fc3-tI-Hn4" id="2Zn-w5-26K"/>
+                        <segue destination="6EF-Is-b7B" kind="show" identifier="Set PIN" id="mn6-Yf-YwO"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wfW-uZ-hKl" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/MiniKeePass/Settings View/SettingsViewController.swift
+++ b/MiniKeePass/Settings View/SettingsViewController.swift
@@ -23,8 +23,9 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
     @IBOutlet weak var pinEnabledSwitch: UISwitch!
     @IBOutlet weak var pinLockTimeoutCell: UITableViewCell!
     
-    @IBOutlet weak var touchIdEnabledCell: UITableViewCell!
-    @IBOutlet weak var touchIdEnabledSwitch: UISwitch!
+    @IBOutlet weak var biometricIdEnabledCell: UITableViewCell!
+    @IBOutlet weak var biometricIdLabel: UILabel!
+    @IBOutlet weak var biometricIdEnabledSwitch: UISwitch!
     
     @IBOutlet weak var deleteAllDataEnabledCell: UITableViewCell!
     @IBOutlet weak var deleteAllDataEnabledSwitch: UISwitch!
@@ -85,8 +86,33 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                                           NSLocalizedString("3 Minutes", comment: "")]
     
     fileprivate var appSettings = AppSettings.sharedInstance()
-    fileprivate var touchIdSupported = false
+    fileprivate var biometricIdSupported = false
     fileprivate var tempPin: String? = nil
+    
+    // This is used for compatiblity of biometric IDs prior to iOS 11
+    fileprivate enum BiometricType {
+        case none
+        case touch
+        case face
+    }
+
+    // This is used for compatiblity of biometric IDs prior to iOS 11
+    fileprivate func biometricType() -> BiometricType {
+        let authContext = LAContext()
+        if #available(iOS 11, *) {
+            let _ = authContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+            switch(authContext.biometryType) {
+            case .none:
+                return .none
+            case .touchID:
+                return .touch
+            case .faceID:
+                return .face
+            }
+        } else {
+            return authContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) ? .touch : .none
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -94,9 +120,19 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
         // Get the version number
         versionLabel.text = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
 
-        // Check if TouchID is supported
+        // Check if Biometric ID is supported
         let laContext = LAContext()
-        touchIdSupported = laContext.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        biometricIdSupported = laContext.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        
+        switch (biometricType()) {
+        case .none:
+            biometricIdLabel.text = NSLocalizedString("Biometric ID", comment: "")
+        case .touch:
+            biometricIdLabel.text = NSLocalizedString("Touch ID", comment: "")
+        case .face:
+            biometricIdLabel.text = NSLocalizedString("Face ID", comment: "")
+        }
+        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -110,7 +146,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
             pinEnabledSwitch.isOn = appSettings.pinEnabled()
             pinLockTimeoutCell.detailTextLabel!.text = pinLockTimeouts[appSettings.pinLockTimeoutIndex()]
             
-            touchIdEnabledSwitch.isOn = touchIdSupported && appSettings.touchIdEnabled()
+            biometricIdEnabledSwitch.isOn = biometricIdSupported && appSettings.biometricIdEnabled()
             
             deleteAllDataEnabledSwitch.isOn = appSettings.deleteOnFailureEnabled()
             deleteAllDataAttemptsCell.detailTextLabel!.text = deleteAllDataAttempts[appSettings.deleteOnFailureAttemptsIndex()]
@@ -152,8 +188,9 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
         
          // Enable/disable the components dependant on settings
         setCellEnabled(pinLockTimeoutCell, enabled: pinEnabled)
-        setCellEnabled(touchIdEnabledCell, enabled: pinEnabled && touchIdSupported)
-        touchIdEnabledSwitch.isEnabled = pinEnabled && touchIdSupported
+        setCellEnabled(biometricIdEnabledCell, enabled: pinEnabled && biometricIdSupported)
+        biometricIdLabel.isEnabled = pinEnabled && biometricIdSupported
+        biometricIdEnabledSwitch.isEnabled = pinEnabled && biometricIdSupported
         setCellEnabled(deleteAllDataEnabledCell, enabled: pinEnabled)
         setCellEnabled(deleteAllDataAttemptsCell, enabled: pinEnabled && deleteOnFailureEnabled)
         setCellEnabled(closeDatabaseTimeoutCell, enabled: closeEnabled)
@@ -267,8 +304,8 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
         }
     }
     
-    @IBAction func touchIdEnabledChanged(_ sender: UISwitch) {
-        self.appSettings?.setTouchIdEnabled(touchIdEnabledSwitch.isOn)
+    @IBAction func biometricIdEnabledChanged(_ sender: UISwitch) {
+        self.appSettings?.setBiometricIdEnabled(biometricIdEnabledSwitch.isOn)
     }
     
     @IBAction func deleteAllDataEnabledChanged(_ sender: UISwitch) {

--- a/MiniKeePass/Settings View/SettingsViewController.swift
+++ b/MiniKeePass/Settings View/SettingsViewController.swift
@@ -28,6 +28,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
     @IBOutlet weak var biometricIdEnabledSwitch: UISwitch!
     
     @IBOutlet weak var deleteAllDataEnabledCell: UITableViewCell!
+    @IBOutlet weak var deleteAllDataEnabledLabel: UILabel!
     @IBOutlet weak var deleteAllDataEnabledSwitch: UISwitch!
     @IBOutlet weak var deleteAllDataAttemptsCell: UITableViewCell!
     
@@ -192,6 +193,8 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
         biometricIdLabel.isEnabled = pinEnabled && biometricIdSupported
         biometricIdEnabledSwitch.isEnabled = pinEnabled && biometricIdSupported
         setCellEnabled(deleteAllDataEnabledCell, enabled: pinEnabled)
+        deleteAllDataEnabledLabel.isEnabled = pinEnabled
+        deleteAllDataEnabledSwitch.isEnabled = pinEnabled
         setCellEnabled(deleteAllDataAttemptsCell, enabled: pinEnabled && deleteOnFailureEnabled)
         setCellEnabled(closeDatabaseTimeoutCell, enabled: closeEnabled)
         setCellEnabled(clearClipboardTimeoutCell, enabled: clearClipboardEnabled)
@@ -208,7 +211,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
         if (identifier == "PIN Lock Timeout") {
             return pinEnabledSwitch.isOn
         } else if (identifier == "Delete All Data Attempts") {
-            return deleteAllDataEnabledSwitch.isOn
+            return deleteAllDataEnabledSwitch.isOn && pinEnabledSwitch.isOn
         } else if (identifier == "Close Database Timeout") {
             return closeDatabaseEnabledSwitch.isOn
         } else if (identifier == "Clear Clipboard Timeout") {

--- a/MiniKeePass/Settings View/SettingsViewController.swift
+++ b/MiniKeePass/Settings View/SettingsViewController.swift
@@ -224,6 +224,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let selectionViewController = segue.destination as! SelectionViewController
         if (segue.identifier == "PIN Lock Timeout") {
+            selectionViewController.title = NSLocalizedString("Lock Timeout", comment: "")
             selectionViewController.items = pinLockTimeouts
             selectionViewController.selectedIndex = (appSettings?.pinLockTimeoutIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in
@@ -231,6 +232,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                 self.navigationController?.popViewController(animated: true)
             }
         } else if (segue.identifier == "Delete All Data Attempts") {
+            selectionViewController.title = NSLocalizedString("Attempts Before Erasing Data", comment: "")
             selectionViewController.items = deleteAllDataAttempts
             selectionViewController.selectedIndex = (appSettings?.deleteOnFailureAttemptsIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in
@@ -238,6 +240,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                 self.navigationController?.popViewController(animated: true)
             }
         } else if (segue.identifier == "Close Database Timeout") {
+            selectionViewController.title = NSLocalizedString("Close Timeout", comment: "")
             selectionViewController.items = closeDatabaseTimeouts
             selectionViewController.selectedIndex = (appSettings?.closeTimeoutIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in
@@ -245,6 +248,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                 self.navigationController?.popViewController(animated: true)
             }
         } else if (segue.identifier == "Password Encoding") {
+            selectionViewController.title = NSLocalizedString("Encoding", comment: "")
             selectionViewController.items = passwordEncodings
             selectionViewController.selectedIndex = (appSettings?.passwordEncodingIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in
@@ -252,6 +256,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                 self.navigationController?.popViewController(animated: true)
             }
         } else if (segue.identifier == "Clear Clipboard Timeout") {
+            selectionViewController.title = NSLocalizedString("Clear Timeout", comment: "")
             selectionViewController.items = clearClipboardTimeouts
             selectionViewController.selectedIndex = (appSettings?.clearClipboardTimeoutIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in
@@ -259,6 +264,7 @@ class SettingsViewController: UITableViewController, PinViewControllerDelegate {
                 self.navigationController?.popViewController(animated: true)
             }
         } else if (segue.identifier == "Remember Passwords") {
+            selectionViewController.title = NSLocalizedString("Remember Passwords", comment: "")
             selectionViewController.items = rememberPasswords
             selectionViewController.selectedIndex = (appSettings?.rememberPasswordsIndex())!
             selectionViewController.itemSelected = { (selectedIndex) in

--- a/MiniKeePass/Settings/AppSettings.h
+++ b/MiniKeePass/Settings/AppSettings.h
@@ -43,8 +43,8 @@ typedef NS_ENUM(NSInteger, RememberPasswords) {
 - (NSInteger)pinFailedAttempts;
 - (void)setPinFailedAttempts:(NSInteger)pinFailedAttempts;
 
-- (BOOL)touchIdEnabled;
-- (void)setTouchIdEnabled:(BOOL)touchIdEnabled;
+- (BOOL)biometricIdEnabled;
+- (void)setBiometricIdEnabled:(BOOL)biometricIdEnabled;
 
 - (BOOL)deleteOnFailureEnabled;
 - (void)setDeleteOnFailureEnabled:(BOOL)deleteOnFailureEnabled;

--- a/MiniKeePass/Settings/AppSettings.h
+++ b/MiniKeePass/Settings/AppSettings.h
@@ -17,6 +17,12 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSInteger, RememberPasswords) {
+    Never = 0,
+    WhenConfigured = 1,
+    Always = 2,
+};
+
 @interface AppSettings : NSObject
 
 + (AppSettings *)sharedInstance;
@@ -54,8 +60,9 @@
 - (NSInteger)closeTimeoutIndex;
 - (void)setCloseTimeoutIndex:(NSInteger)closeTimeoutIndex;
 
-- (BOOL)rememberPasswordsEnabled;
-- (void)setRememberPasswordsEnabled:(BOOL)rememberPasswordsEnabled;
+- (RememberPasswords)rememberPasswords;
+- (NSInteger)rememberPasswordsIndex;
+- (void)setRememberPasswordsIndex:(NSInteger)rememberPasswordsIndex;
 
 - (BOOL)hidePasswords;
 - (void)setHidePasswords:(BOOL)hidePasswords;

--- a/MiniKeePass/Settings/AppSettings.m
+++ b/MiniKeePass/Settings/AppSettings.m
@@ -28,6 +28,7 @@
 #define PIN_LOCK_TIMEOUT           @"pinLockTimeout"
 #define PIN_FAILED_ATTEMPTS        @"pinFailedAttempts"
 #define TOUCH_ID_ENABLED           @"touchIdEnabled"
+#define BIOMETRIC_ID_ENABLED       @"biometricIdEnabled"
 #define DELETE_ON_FAILURE_ENABLED  @"deleteOnFailureEnabled"
 #define DELETE_ON_FAILURE_ATTEMPTS @"deleteOnFailureAttempts"
 #define CLOSE_ENABLED              @"closeEnabled"
@@ -280,8 +281,8 @@ static AppSettings *sharedInstance;
         [self setRememberPasswordsIndex:(2)];
     }
     // Migrate touch ID enabled to the keychain service
-    BOOL touchIDEnabled = [userDefaults boolForKey:TOUCH_ID_ENABLED];
-    [self setTouchIdEnabled:touchIDEnabled];
+    BOOL biometricIDEnabled = [userDefaults boolForKey:TOUCH_ID_ENABLED];
+    [self setBiometricIdEnabled:biometricIDEnabled];
 
     // Upgrade from v1 to v2 keychain services
     [KeychainUtils renameAllForServiceName:KEYCHAIN_PASSWORDS_V1_SERVICE newServiceName:KEYCHAIN_PASSWORDS_V2_SERVICE];
@@ -370,16 +371,16 @@ static AppSettings *sharedInstance;
     return [userDefaults boolForKey:DELETE_ON_FAILURE_ENABLED];
 }
 
-- (BOOL)touchIdEnabled {
-    NSString *string = [KeychainUtils stringForKey:TOUCH_ID_ENABLED andServiceName:KEYCHAIN_PIN_SERVICE];
+- (BOOL)biometricIdEnabled {
+    NSString *string = [KeychainUtils stringForKey:BIOMETRIC_ID_ENABLED andServiceName:KEYCHAIN_PIN_SERVICE];
     if (string == nil) {
         return false;
     }
     return [string boolValue];
 }
 
-- (void)setTouchIdEnabled:(BOOL)touchIdEnabled {
-    [KeychainUtils setString:BOOLToNSString(touchIdEnabled) forKey:TOUCH_ID_ENABLED andServiceName:KEYCHAIN_PIN_SERVICE];
+- (void)setBiometricIdEnabled:(BOOL)biometricIdEnabled {
+    [KeychainUtils setString:BOOLToNSString(biometricIdEnabled) forKey:BIOMETRIC_ID_ENABLED andServiceName:KEYCHAIN_PIN_SERVICE];
 }
 
 - (void)setDeleteOnFailureEnabled:(BOOL)deleteOnFailureEnabled {

--- a/MiniKeePass/Settings/AppSettings.m
+++ b/MiniKeePass/Settings/AppSettings.m
@@ -32,6 +32,7 @@
 #define DELETE_ON_FAILURE_ATTEMPTS @"deleteOnFailureAttempts"
 #define CLOSE_ENABLED              @"closeEnabled"
 #define CLOSE_TIMEOUT              @"closeTimeout"
+#define REMEMBER_PASSWORDS         @"rememberPasswords"
 #define REMEMBER_PASSWORDS_ENABLED @"rememberPasswordsEnabled"
 #define HIDE_PASSWORDS             @"hidePasswords"
 #define SORT_ALPHABETICALLY        @"sortAlphabetically"
@@ -57,6 +58,12 @@ static NSInteger pinLockTimeoutValues[] = {
     60,
     120,
     300
+};
+
+static RememberPasswords rememberPasswordsValues[] = {
+    Never,
+    WhenConfigured,
+    Always
 };
 
 static NSInteger deleteOnFailureAttemptsValues[] = {
@@ -118,7 +125,7 @@ static AppSettings *sharedInstance;
         [defaultsDict setValue:[NSNumber numberWithInt:1] forKey:DELETE_ON_FAILURE_ATTEMPTS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:CLOSE_ENABLED];
         [defaultsDict setValue:[NSNumber numberWithInt:4] forKey:CLOSE_TIMEOUT];
-        [defaultsDict setValue:[NSNumber numberWithBool:NO] forKey:REMEMBER_PASSWORDS_ENABLED];
+        [defaultsDict setValue:[NSNumber numberWithInt:0] forKey:REMEMBER_PASSWORDS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:HIDE_PASSWORDS];
         [defaultsDict setValue:[NSNumber numberWithBool:YES] forKey:SORT_ALPHABETICALLY];
         [defaultsDict setValue:[NSNumber numberWithBool:NO] forKey:SEARCH_TITLE_ONLY];
@@ -187,6 +194,10 @@ static AppSettings *sharedInstance;
         if ([self versionCompare:version rhsVersion:@"1.5.2"] <= 0) {
             [self upgrade152];
         }
+    
+        if ([self versionCompare:version rhsVersion:@"1.7.2"] <= 0) {
+            [self upgrade172];
+        }
     }
 
     NSString *currentVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
@@ -219,6 +230,18 @@ static AppSettings *sharedInstance;
     [userDefaults removeObjectForKey:PIN_ENABLED];
     [userDefaults removeObjectForKey:PIN_LOCK_TIMEOUT];
     [userDefaults removeObjectForKey:PIN_FAILED_ATTEMPTS];
+}
+
+// Upgrade configuration from 1.7.2
+- (void)upgrade172 {
+    // Migrate the remember passwords enabled setting
+    BOOL rememberPasswordsEnabled = [userDefaults boolForKey:REMEMBER_PASSWORDS_ENABLED];
+    if (rememberPasswordsEnabled) {
+        [self setRememberPasswordsIndex:(2)];
+    }
+
+    // Remove the old keys
+    [userDefaults removeObjectForKey:REMEMBER_PASSWORDS_ENABLED];
 }
 
 - (NSString *)version {
@@ -357,12 +380,17 @@ static AppSettings *sharedInstance;
     [userDefaults setInteger:closeTimeoutIndex forKey:CLOSE_TIMEOUT];
 }
 
-- (BOOL)rememberPasswordsEnabled {
-    return [userDefaults boolForKey:REMEMBER_PASSWORDS_ENABLED];
+- (RememberPasswords)rememberPasswords {
+    NSInteger rememberPasswordsIndex = [self rememberPasswordsIndex];
+    return rememberPasswordsValues[rememberPasswordsIndex];
 }
 
-- (void)setRememberPasswordsEnabled:(BOOL)rememberPasswordsEnabled {
-    [userDefaults setBool:rememberPasswordsEnabled forKey:REMEMBER_PASSWORDS_ENABLED];
+- (NSInteger)rememberPasswordsIndex {
+    return [userDefaults integerForKey:REMEMBER_PASSWORDS];
+}
+
+- (void)setRememberPasswordsIndex:(NSInteger)rememberPasswordsIndex {
+    [userDefaults setInteger:rememberPasswordsIndex forKey:REMEMBER_PASSWORDS];
 }
 
 - (BOOL)hidePasswords {

--- a/MiniKeePass/Utils/KeychainUtils.h
+++ b/MiniKeePass/Utils/KeychainUtils.h
@@ -29,9 +29,22 @@
 
 #import <UIKit/UIKit.h>
 
+#define KEYCHAIN_VERSION_SERVICE   @"com.jflan.MiniKeePass.version"
 #define KEYCHAIN_PIN_SERVICE       @"com.jflan.MiniKeePass.pin"
-#define KEYCHAIN_PASSWORDS_SERVICE @"com.jflan.MiniKeePass.passwords"
-#define KEYCHAIN_KEYFILES_SERVICE  @"com.jflan.MiniKeePass.keyfiles"
+
+// The V2 services protect against a malicious user rolling back the version
+// to a version that didn't check for version compatibility using the keychain
+// and thus was vulnerable to vulnerabilites in the prior versions. Specifically,
+// there was a vulnerability where a malicious user could delete the app and
+// and install an old version which would set the PIN to disabled but database
+// passwords that were remembered were not forgotten.
+#define KEYCHAIN_PASSWORDS_V1_SERVICE @"com.jflan.MiniKeePass.passwords"
+#define KEYCHAIN_PASSWORDS_V2_SERVICE @"com.jflan.MiniKeePass.passwords2"
+#define KEYCHAIN_PASSWORDS_SERVICE KEYCHAIN_PASSWORDS_V2_SERVICE
+
+#define KEYCHAIN_KEYFILES_V1_SERVICE  @"com.jflan.MiniKeePass.keyfiles"
+#define KEYCHAIN_KEYFILES_V2_SERVICE  @"com.jflan.MiniKeePass.keyfiles2"
+#define KEYCHAIN_KEYFILES_SERVICE  KEYCHAIN_KEYFILES_V2_SERVICE
 
 @interface KeychainUtils : NSObject
 
@@ -39,5 +52,6 @@
 + (BOOL)setString:(NSString *)string forKey:(NSString *)key andServiceName:(NSString *)serviceName;
 + (BOOL)deleteStringForKey:(NSString *)key andServiceName:(NSString *)serviceName;
 + (BOOL)deleteAllForServiceName:(NSString *)serviceName;
++ (BOOL)renameAllForServiceName:(NSString *)serviceName newServiceName:(NSString *)newServiceName;
 
 @end

--- a/MiniKeePass/Utils/KeychainUtils.m
+++ b/MiniKeePass/Utils/KeychainUtils.m
@@ -124,4 +124,26 @@
     return status == errSecSuccess;
 }
 
++ (BOOL)renameAllForServiceName:(NSString *)serviceName newServiceName:(NSString *)newServiceName {
+    OSStatus status;
+    
+    // Check the arguments
+    if (serviceName == nil) {
+        return NO;
+    }
+    
+    NSDictionary *query = @{
+                            (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
+                            (__bridge id)kSecAttrService : serviceName,
+                            };
+    
+    NSDictionary *attributesToUpdate = @{
+                            (__bridge id)kSecAttrService : newServiceName,
+                            };
+
+    status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)attributesToUpdate);
+    
+    return status == errSecSuccess;
+}
+
 @end

--- a/MiniKeePass/Web Browser View/WebBrowserViewController.swift
+++ b/MiniKeePass/Web Browser View/WebBrowserViewController.swift
@@ -29,6 +29,18 @@ class WebBrowserViewController: UIViewController, WKNavigationDelegate {
     @objc var url: URL?
     @objc var entry: KdbEntry?
 
+    @objc class func clearState() {
+        HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
+        
+        if #available(iOS 9.0, *) {
+            WKWebsiteDataStore.default().fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+                records.forEach { record in
+                    WKWebsiteDataStore.default().removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {})
+                }
+            }
+        }
+    }
+
     override func loadView() {
         super.loadView()
         

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN Schutz";
-"Delete All Data on PIN Failure" = "Alle Daten bei falscher PIN löschen";
 "Close Database on Timeout" = "Datenbank bei Zeitüberschreitung schließen";
 "Remember Database Passwords" = "Datenbank Passwörter merken";
 "Hide Passwords" = "Passwörter verstecken";

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -86,7 +86,6 @@
 "Settings" = "Einstellungen";
 "PIN Enabled" = "PIN aktiviert";
 "Touch ID" = "Touch ID"; // FIXME
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported."; // FIXME
 "Lock Timeout" = "Sperrzeit";
 "Immediately" = "Sofort";
 "30 Seconds" = "30 Sekunden";

--- a/en.lproj/InfoPlist.strings
+++ b/en.lproj/InfoPlist.strings
@@ -1,2 +1,4 @@
 /* Localized versions of Info.plist keys */
 
+"NSFaceIDUsageDescription" = "This app requires Face ID permission to authenticate using Face recognition rather than the PIN.";
+

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -85,8 +85,9 @@
 // Settings Page
 "Settings" = "Settings";
 "PIN Enabled" = "PIN Enabled";
+"Biometric ID" = "Biometric ID";
 "Touch ID" = "Touch ID";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported.";
+"Face ID" = "Face ID";
 "Lock Timeout" = "Lock Timeout";
 "Immediately" = "Immediately";
 "30 Seconds" = "30 Seconds";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2011 Jason Rush and John Flanagan. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -114,6 +114,11 @@
 "Delete All Data on PIN Failure" = "Delete All Data on PIN Failure";
 "Close Database on Timeout" = "Close Database on Timeout";
 "Remember Database Passwords" = "Remember Database Passwords";
+"Remember" = "Remember";
+"Forget Password" = "Forget Password";
+"Never" = "Never";
+"When Configured" = "When Configured";
+"Always" = "Always";
 "Hide Passwords" = "Hide Passwords";
 "Password Encoding" = "Password Encoding";
 "Clear Clipboard on Timeout" = "Clear Clipboard on Timeout";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 "5 Minutes" = "5 Minutes";
 "Enabled" = "Enabled";
 "Attempts" = "Attempts";
+"Attempts Before Erasing Data" = "Attempts Before Erasing Data";
 "Close Enabled" = "Close Enabled";
 "Close Timeout" = "Close Timeout";
 "Hide Passwords" = "Hide Passwords";
@@ -112,7 +113,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN Protection";
-"Delete All Data on PIN Failure" = "Delete All Data on PIN Failure";
 "Close Database on Timeout" = "Close Database on Timeout";
 "Remember Database Passwords" = "Remember Database Passwords";
 "Remember" = "Remember";
@@ -125,6 +125,7 @@
 "Clear Clipboard on Timeout" = "Clear Clipboard on Timeout";
 "Clear Timeout" = "Clear Timeout";
 "Prevent unauthorized access to MiniKeePass with a PIN." = "Prevent unauthorized access to MiniKeePass with a PIN.";
+"Erase Data On Failure" = "Erase Data On Failure";
 "Delete all files and passwords after too many failed attempts." = "Delete all files and passwords after too many failed attempts.";
 "Automatically close an open database after the selected timeout." = "Automatically close an open database after the selected timeout.";
 "Stores remembered database passwords in the devices's secure keychain." = "Stores remembered database passwords in the devices's secure keychain.";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -115,6 +115,7 @@
 "PIN Protection" = "PIN Protection";
 "Close Database on Timeout" = "Close Database on Timeout";
 "Remember Database Passwords" = "Remember Database Passwords";
+"Remember Passwords" = "Remember Passwords";
 "Remember" = "Remember";
 "Forget Password" = "Forget Password";
 "Never" = "Never";

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -89,7 +89,6 @@
 "Settings" = "Réglages";
 "PIN Enabled" = "Code PIN Activé";
 "Touch ID" = "Touch ID"; // FIXME
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported."; // FIXME
 "Lock Timeout" = "Délai de verrouillage";
 "Immediately" = "Immédiatement";
 "30 Seconds" = "30 Secondes";

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -113,7 +113,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "Protéger le code PIN";
-"Delete All Data on PIN Failure" = "Supprimer toutes les données sur échec code PIN";
 "Close Database on Timeout" = "Fermer la BDD après Timeout";
 "Remember Database Passwords" = "Mémoriser les MdP BDD";
 "Hide Passwords" = "Masquer les MdP";

--- a/it.lproj/Localizable.strings
+++ b/it.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "Protezione PIN";
-"Delete All Data on PIN Failure" = "Elimina tutti i dati se il PIN è errato";
 "Close Database on Timeout" = "Chiudi il database allo scadere di un intervallo";
 "Remember Database Passwords" = "Ricorda le password dei database";
 "Hide Passwords" = "Nascondi le password";

--- a/it.lproj/Localizable.strings
+++ b/it.lproj/Localizable.strings
@@ -86,7 +86,6 @@
 "Settings" = "Impostazioni";
 "PIN Enabled" = "PIN abilitato";
 "Touch ID" = "Touch ID"; // FIXME
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported."; // FIXME
 "Lock Timeout" = "Intervallo blocco";
 "Immediately" = "Immediatamente";
 "30 Seconds" = "30 secondi";

--- a/ja.lproj/Localizable.strings
+++ b/ja.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2011 Jason Rush and John Flanagan. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -86,7 +86,6 @@
 "Settings" = "設定";
 "PIN Enabled" = "PIN Enabled";
 "Touch ID" = "Touch ID"; // FIXME
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported."; // FIXME
 "Lock Timeout" = "Lock Timeout";
 "Immediately" = "Immediately";
 "30 Seconds" = "30 秒";

--- a/ja.lproj/Localizable.strings
+++ b/ja.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "日本語EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN Protection";
-"Delete All Data on PIN Failure" = "Delete All Data on PIN Failure";
 "Close Database on Timeout" = "Close Database on Timeout";
 "Remember Database Passwords" = "Remember Database Passwords";
 "Hide Passwords" = "Hide Passwords";

--- a/nl.lproj/Localizable.strings
+++ b/nl.lproj/Localizable.strings
@@ -112,7 +112,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN Bescherming";
-"Delete All Data on PIN Failure" = "Verwijder Alle Data bij falen PIN";
 "Close Database on Timeout" = "Sluit Database bij Timeout";
 "Remember Database Passwords" = "Databasewachtwoorden Onthouden";
 "Hide Passwords" = "Verberg Wachtwoorden";

--- a/nl.lproj/Localizable.strings
+++ b/nl.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "Settings" = "Voorkeuren";
 "PIN Enabled" = "PIN Geactiveerd";
 "Touch ID" = "Touch ID"; // FIXME
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use your fingerprint as an alternative to entering a PIN if supported."; // FIXME
 "Lock Timeout" = "Vergrendel Timeout";
 "Immediately" = "Onmiddellijk";
 "30 Seconds" = "30 Seconden";

--- a/pt.lproj/Localizable.strings
+++ b/pt.lproj/Localizable.strings
@@ -86,7 +86,6 @@
 "Settings" = "Ajustes";
 "PIN Enabled" = "Ativar PIN";
 "Touch ID" = "Touch ID";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Use a sua impressão digital como alternativa ao PIN (se compatível).";
 "Lock Timeout" = "Bloqueio Automático";
 "Immediately" = "Imediatamente";
 "30 Seconds" = "30 segundos";

--- a/pt.lproj/Localizable.strings
+++ b/pt.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "EUC Japonês";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "Proteção por PIN";
-"Delete All Data on PIN Failure" = "Apagar Dados ao Inserir PIN Incorreto";
 "Close Database on Timeout" = "Fechar Banco de Dados Automaticamente";
 "Remember Database Passwords" = "Memorizar Senhas de Bancos de Dados";
 "Hide Passwords" = "Ocultar Senhas";

--- a/ru.lproj/Localizable.strings
+++ b/ru.lproj/Localizable.strings
@@ -112,7 +112,6 @@
 "Japanese EUC" = "Японская EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "Защита PIN-кодом";
-"Delete All Data on PIN Failure" = "Удалить все данные при вводе неправильного PIN-кода";
 "Close Database on Timeout" = "Закрыть базу данных по истечении времени";
 "Remember Database Passwords" = "Запоминать пароли от баз данных";
 "Hide Passwords" = "Скрывать пароли";

--- a/ru.lproj/Localizable.strings
+++ b/ru.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "Settings" = "Настройки";
 "PIN Enabled" = "PIN-код включен";
 "Touch ID" = "Touch ID";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Используйте ваш отпечаток пальца как альтернативу вводу PIN, если поддерживается.";
 "Lock Timeout" = "Тайм-аут блокировки";
 "Immediately" = "Сразу";
 "30 Seconds" = "30 сек.";

--- a/sv.lproj/Localizable.strings
+++ b/sv.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN-skydd";
-"Delete All Data on PIN Failure" = "Radera all data efter fel angiven PIN";
 "Close Database on Timeout" = "Stäng databas efter låsningstid";
 "Remember Database Passwords" = "Kom ihåg databaslösenord";
 "Hide Passwords" = "Göm lösenord";

--- a/sv.lproj/Localizable.strings
+++ b/sv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2011 Jason Rush and John Flanagan. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -86,7 +86,6 @@
 "Settings" = "Inställningar";
 "PIN Enabled" = "PIN aktiverad";
 "Touch ID" = "Touch ID";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Använd ditt fingeravtryck som alternativ till PIN om stöd finns.";
 "Lock Timeout" = "Låsningstid";
 "Immediately" = "Direkt";
 "30 Seconds" = "30 sekunder";

--- a/tr.lproj/Localizable.strings
+++ b/tr.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN Koruma";
-"Delete All Data on PIN Failure" = "PIN Hatasında Tüm Verileri Sil";
 "Close Database on Timeout" = "Zaman aşımında veritabanını kapat";
 "Remember Database Passwords" = "Database şiresini hatırla";
 "Hide Passwords" = "Şifreyi gizle";

--- a/tr.lproj/Localizable.strings
+++ b/tr.lproj/Localizable.strings
@@ -86,7 +86,6 @@
 "Settings" = "Ayarlar";
 "PIN Enabled" = "PIN Etkin";
 "Touch ID" = "Touch ID";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "Destekleniyorsa bir PIN girişi için parmak izinizi kullanın.";
 "Lock Timeout" = "Kilitleme için zaman aşımı";
 "Immediately" = "Hemen";
 "30 Seconds" = "30 Saniye";

--- a/zh-Hans.lproj/Localizable.strings
+++ b/zh-Hans.lproj/Localizable.strings
@@ -110,7 +110,6 @@
 "Japanese EUC" = "Japanese EUC";
 "ISO-2022-JP" = "ISO-2022-JP";
 "PIN Protection" = "PIN 码保护";
-"Delete All Data on PIN Failure" = "当 PIN 码验证失败时删除所有数据";
 "Close Database on Timeout" = "在指定时间后关闭数据库";
 "Remember Database Passwords" = "记住数据库密码";
 "Hide Passwords" = "密码在默认状态下不可见";

--- a/zh-Hans.lproj/Localizable.strings
+++ b/zh-Hans.lproj/Localizable.strings
@@ -86,7 +86,6 @@
 "Settings" = "设置";
 "PIN Enabled" = "启用 PIN 码";
 "Touch ID" = "Touch ID 指纹识别";
-"Use your fingerprint as an alternative to entering a PIN if supported." = "在支持Touch ID 指纹识别的设备上可以使用指纹识别代替PIN码访问本应用";
 "Lock Timeout" = "多长时间后锁定？";
 "Immediately" = "立刻";
 "30 Seconds" = "30 秒";


### PR DESCRIPTION
A back button has been added to the top of the set PIN screen. This 
prevents an infinite loop of set PIN screens until the user properly
enters the same PIN twice. It allows a user to cancel the action
without actually setting a PIN followed by removing it.

This was manually tested using the simulator with an iPhone XR with
iOS 12.1.

#652 